### PR TITLE
Phase 3.2 v2 — Classifier production wiring + full category coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ skills-lock.json
 # classifier test fixtures (local only — real Ross Built PDFs, never committed per preflight R8)
 /__tests__/fixtures/classifier/.local/
 
+# classifier eval intermediate output (regenerable, varies per run — final results are pasted into qa-branch3-phase3.2-v2.md)
+/qa-reports/.eval/
+
 # /gsd-map-codebase output, regenerable, kept local
 /.planning/
 

--- a/__tests__/api-ingest.test.ts
+++ b/__tests__/api-ingest.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Phase 3.2 v2 Step 2 — /api/ingest route shape fence.
+ *
+ * Static structural validation that the route file conforms to the
+ * Phase 3.2 v2 contract:
+ *   - auth gate via getCurrentMembership() (Phase A pattern, NOT
+ *     auth.getUser-only and NOT requireOrgId() which the legacy
+ *     /api/invoices/parse uses)
+ *   - org scoping on every Supabase query
+ *   - calls classifyDocument from src/lib/ingestion/classify (the
+ *     post-Step-1 location, NOT the v1 src/lib/claude/classify-document)
+ *   - inserts into document_extractions with invoice_id=null and
+ *     verification_status='pending'; leaves target_entity_type/_id NULL
+ *   - returns the contract payload {extraction_id, classified_type,
+ *     classification_confidence}
+ *   - does NOT touch src/app/api/invoices/parse (legacy untouched)
+ *
+ * Live happy-path coverage is exercised by:
+ *   - __tests__/document-classifier.test.ts (calls classifyDocument
+ *     directly against real fixtures, RUN_CLASSIFIER_EVAL=1)
+ *   - the QA report's manual cutover-readiness checklist (curl POST)
+ *
+ * Spinning up the Next.js route in-process inside this static runner
+ * would require a synthesized request context with auth cookies; that
+ * adds fragile harness code without strengthening the contract. The
+ * static checks below cover the auth/org/contract surface; the eval
+ * harness covers the classifier itself.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { strict as assert } from "node:assert";
+
+const ROUTE_PATH = "src/app/api/ingest/route.ts";
+const LEGACY_ROUTE_PATH = "src/app/api/invoices/parse/route.ts";
+const CLASSIFIER_PATH = "src/lib/ingestion/classify.ts";
+
+type Case = { name: string; fn: () => void };
+const cases: Case[] = [];
+const test = (name: string, fn: () => void) => cases.push({ name, fn });
+
+// ── Existence ──────────────────────────────────────────────────
+test("route file exists at src/app/api/ingest/route.ts", () => {
+  assert.ok(existsSync(ROUTE_PATH), `missing ${ROUTE_PATH}`);
+});
+
+test("classifier exists at post-Step-1 location src/lib/ingestion/classify.ts", () => {
+  assert.ok(existsSync(CLASSIFIER_PATH), `missing ${CLASSIFIER_PATH}`);
+});
+
+test("legacy /api/invoices/parse route still exists (untouched cutover guarantee)", () => {
+  assert.ok(existsSync(LEGACY_ROUTE_PATH), `missing ${LEGACY_ROUTE_PATH}`);
+});
+
+// ── Route content checks ───────────────────────────────────────
+const routeSource = existsSync(ROUTE_PATH) ? readFileSync(ROUTE_PATH, "utf8") : "";
+
+test("route imports getCurrentMembership from @/lib/org/session", () => {
+  assert.match(
+    routeSource,
+    /import\s*\{[^}]*getCurrentMembership[^}]*\}\s*from\s*['"]@\/lib\/org\/session['"]/,
+    "route must use getCurrentMembership() (Phase A standard)"
+  );
+});
+
+test("route does NOT use requireOrgId (legacy pattern)", () => {
+  assert.ok(
+    !/requireOrgId/.test(routeSource),
+    "route must use getCurrentMembership() instead of requireOrgId() so the membership object (with role) is available for future write authz"
+  );
+});
+
+test("route imports classifyDocument from @/lib/ingestion/classify", () => {
+  assert.match(
+    routeSource,
+    /import\s*\{[^}]*classifyDocument[^}]*\}\s*from\s*['"]@\/lib\/ingestion\/classify['"]/,
+    "route must call the relocated classifier, not the legacy src/lib/claude/classify-document"
+  );
+});
+
+test("route enforces auth: throws ApiError 401 when membership is null", () => {
+  // We accept either an explicit Not authenticated message or a 401 status
+  // to avoid coupling the test to wording; either signals the auth gate.
+  const hasGate =
+    /if\s*\(!membership\)\s*throw\s+new\s+ApiError\([^)]*401\)/.test(routeSource) ||
+    /if\s*\(!membership\)[\s\S]{0,80}?401/.test(routeSource);
+  assert.ok(hasGate, "route must reject unauthenticated callers with 401");
+});
+
+test("route inserts document_extractions with invoice_id=null", () => {
+  // Match a key/value pair in the .insert({...}) block. The pattern is
+  // permissive about whitespace and quote style.
+  assert.match(
+    routeSource,
+    /\binvoice_id\s*:\s*null\b/,
+    "row must be inserted with invoice_id=null per Phase 3.2 v2 scope (target_entity_type also stays NULL until commit time)"
+  );
+});
+
+test("route inserts document_extractions with verification_status='pending'", () => {
+  assert.match(
+    routeSource,
+    /verification_status\s*:\s*['"]pending['"]/,
+    "initial row state must be 'pending' per spec — gets updated after classify, soft-deleted on classifier failure"
+  );
+});
+
+test("route does NOT set target_entity_type or target_entity_id at insert time", () => {
+  // Defensively check both columns are absent from any insert/update payload.
+  // Phase 3.3+ owns these fields; Phase 3.2 v2 must not pre-populate.
+  assert.ok(
+    !/target_entity_type\s*:/.test(routeSource),
+    "v2 must leave target_entity_type NULL — Phase 3.3+ populates at commit time"
+  );
+  assert.ok(
+    !/target_entity_id\s*:/.test(routeSource),
+    "v2 must leave target_entity_id NULL — Phase 3.3+ populates at commit time"
+  );
+});
+
+test("route filters Supabase updates by org_id (org scoping)", () => {
+  // Every .update() against document_extractions in this route must be
+  // accompanied by .eq("org_id", membership.org_id) so a stolen extraction
+  // id from another org cannot be mutated.
+  const hasOrgScopedUpdate =
+    /\.update\([\s\S]{0,400}?\)[\s\S]{0,200}?\.eq\(["']org_id["']\s*,\s*membership\.org_id\s*\)/.test(
+      routeSource
+    );
+  assert.ok(
+    hasOrgScopedUpdate,
+    "every .update() on document_extractions must filter by org_id=membership.org_id (RLS is a backstop, not a substitute)"
+  );
+});
+
+test("route storage path is org-scoped (prevents cross-tenant overwrite)", () => {
+  assert.match(
+    routeSource,
+    /\$\{\s*membership\.org_id\s*\}\/ingest\//,
+    "storage path must be ${membership.org_id}/ingest/... so cross-tenant uploads cannot collide"
+  );
+});
+
+test("route returns the contract payload {extraction_id, classified_type, classification_confidence}", () => {
+  // NextResponse.json({...}) must include all three keys.
+  assert.match(routeSource, /extraction_id\s*:/, "response missing extraction_id");
+  assert.match(
+    routeSource,
+    /classified_type\s*:/,
+    "response missing classified_type"
+  );
+  assert.match(
+    routeSource,
+    /classification_confidence\s*:/,
+    "response missing classification_confidence"
+  );
+});
+
+test("route handles PlanLimitError → 429 with structured fields", () => {
+  // Match either the import or the runtime check. The spec's plan-limit
+  // pattern returns {error, current, limit, plan} at status 429.
+  assert.match(
+    routeSource,
+    /PlanLimitError/,
+    "route must handle PlanLimitError to surface 429 with current/limit/plan fields"
+  );
+  assert.match(routeSource, /\b429\b/, "PlanLimitError must map to HTTP 429");
+});
+
+test("route soft-deletes document_extractions row on classifier failure (no 'failed' enum value)", () => {
+  // The verification_status enum is ('pending','partial','verified',
+  // 'rejected'). There is no 'failed' value, so the spec's
+  // "row status=failed on classifier failure" maps to soft-delete + log
+  // here. Future schema work could add 'failed' if telemetry shows the
+  // soft-delete trail isn't enough.
+  assert.match(
+    routeSource,
+    /deleted_at\s*:\s*new\s+Date\(\)\.toISOString\(\)/,
+    "route must soft-delete the document_extractions row on classifier failure to keep it out of active queries"
+  );
+});
+
+// ── Legacy route untouched ─────────────────────────────────────
+const legacySource = existsSync(LEGACY_ROUTE_PATH)
+  ? readFileSync(LEGACY_ROUTE_PATH, "utf8")
+  : "";
+
+test("legacy /api/invoices/parse route does NOT import the new classifier (cutover boundary)", () => {
+  assert.ok(
+    !/from\s*['"]@\/lib\/ingestion\/classify['"]/.test(legacySource),
+    "legacy /api/invoices/parse must remain classifier-free in v2 — Phase 3.10 owns the cutover"
+  );
+});
+
+test("legacy /api/invoices/parse route still uses requireOrgId (proves v2 did not modify it)", () => {
+  // This is a stability fence: if a future change migrates the legacy
+  // route to getCurrentMembership(), this test must be updated as part
+  // of that migration. v2's contract is "legacy 100% untouched".
+  assert.match(
+    legacySource,
+    /requireOrgId/,
+    "legacy route should still use requireOrgId — v2 must not modify it"
+  );
+});
+
+// ── Runner ─────────────────────────────────────────────────────
+let failed = 0;
+for (const c of cases) {
+  try {
+    c.fn();
+    console.log(`PASS  ${c.name}`);
+  } catch (e) {
+    failed++;
+    console.log(`FAIL  ${c.name}`);
+    console.log(`      ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+console.log("");
+if (failed > 0) {
+  console.error(`${failed} of ${cases.length} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log(`${cases.length} test(s) passed`);
+}

--- a/__tests__/document-classifier.test.ts
+++ b/__tests__/document-classifier.test.ts
@@ -71,6 +71,12 @@ const TEN_CATEGORIES = [
 ] as const;
 type Category = (typeof TEN_CATEGORIES)[number];
 
+// Subdirectories under FIXTURE_ROOT that are NOT classifier categories.
+// Add entries here as needed (e.g., 'experiments', 'archive').
+// Skipped before the TEN_CATEGORIES assertion so they don't fail
+// "unknown category" but also don't get evaluated.
+const SKIPPED_DIRS = new Set<string>(["dogfood"]);
+
 type Row = {
   category: Category;
   filename: string;
@@ -103,6 +109,7 @@ function discoverCategories(root: string): Category[] {
   const subdirs = readdirSync(root, { withFileTypes: true })
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
+    .filter((name) => !SKIPPED_DIRS.has(name))
     .sort();
 
   const known = new Set<string>(TEN_CATEGORIES);
@@ -110,7 +117,7 @@ function discoverCategories(root: string): Category[] {
   assert.ok(
     unknown.length === 0,
     `fixture subfolder(s) not in TEN_CATEGORIES enum: ${unknown.join(", ")}. ` +
-      "Either rename to match an enum value or add the value to TEN_CATEGORIES + the classifier prompt."
+      "Either rename to match an enum value, add the value to TEN_CATEGORIES + the classifier prompt, or add it to SKIPPED_DIRS if it is intentionally not a classifier category."
   );
 
   return subdirs as Category[];

--- a/__tests__/document-classifier.test.ts
+++ b/__tests__/document-classifier.test.ts
@@ -65,7 +65,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 
 async function main() {
   // Import after dotenv so the SDK has its API key.
-  const { classifyDocument } = await import("../src/lib/claude/classify-document");
+  const { classifyDocument } = await import("../src/lib/ingestion/classify");
   const { createClient } = await import("@supabase/supabase-js");
 
   assert.ok(existsSync(FIXTURE_ROOT), `fixture root missing: ${FIXTURE_ROOT}`);

--- a/__tests__/document-classifier.test.ts
+++ b/__tests__/document-classifier.test.ts
@@ -1,19 +1,35 @@
 /**
- * Phase 3.2 — Document classifier accuracy harness.
+ * Phase 3.2 v2 Step 3 — Document classifier eval, full 10-category coverage.
  *
- * Iterates __tests__/fixtures/classifier/.local/{invoice,proposal,other}/
- * fixtures, calls classifyDocument() directly (no HTTP / no /api/ingest),
- * and reports per-fixture results, per-category accuracy, a confusion
- * matrix, and cache-hit verification against api_usage.
+ * Discovers fixtures dynamically from __tests__/fixtures/classifier/.local/
+ * subfolders. The subfolder name IS the expected classified_type.
+ * Calls classifyDocument() directly (no HTTP / no /api/ingest), reports
+ * per-fixture results, per-category accuracy, a confusion matrix, and
+ * cache-hit verification against api_usage.
  *
  * Env-gated: skipped unless RUN_CLASSIFIER_EVAL=1 is set. Each run makes
- * 15 live Claude Sonnet calls (~2-3s each) so it is opt-in. The default
- * `npm test` invocation treats this file as a no-op.
+ * one live Claude Sonnet call per fixture (~2-3s each) so it is opt-in.
+ * Default `npm test` invocation treats this file as a no-op.
  *
  * Fixture source directories are gitignored under .local/ per preflight
- * Risk R8 (real Ross Built documents never commit).
+ * Risk R8 (real Ross Built documents never commit). The TEN_CATEGORIES
+ * constant below is the full classifier enum from
+ * src/lib/ingestion/classify.ts; subfolders not in that list are flagged
+ * as authoring errors.
+ *
+ * Exit gate (Phase 3.2 v2 Path B per Jake's decisions in prompt 153):
+ *   1. Overall accuracy ≥ 90%
+ *   2. Per-category accuracy ≥ 80% on FAT categories (≥3 fixtures)
+ *   3. THIN categories (<3 fixtures) — any miss flagged as INVESTIGATE,
+ *      counted in overall accuracy but does NOT short-circuit the gate
+ *      via the per-category check (which requires ≥3 fixtures to be
+ *      statistically meaningful)
+ *
+ * The thin-category misses are reported as "INVESTIGATE — insufficient
+ * sample" in the QA report, never excused as sample-size noise without
+ * a prompt-side investigation first.
  */
-import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { readFileSync, readdirSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { strict as assert } from "node:assert";
 import * as dotenv from "dotenv";
@@ -29,12 +45,31 @@ if (!RUN_EVAL) {
 dotenv.config({ path: ".env.local" });
 
 const FIXTURE_ROOT = "__tests__/fixtures/classifier/.local";
+const RESULTS_DIR = "qa-reports/.eval";
+const RESULTS_FILE = join(RESULTS_DIR, "phase3.2-v2-eval.md");
 const ORG_ID = "00000000-0000-0000-0000-000000000001";
-const CATEGORIES = ["invoice", "proposal", "plan", "other"] as const;
 const CALL_TIMEOUT_MS = 15_000;
-const ACCURACY_GATE = 0.9;
 
-type Category = (typeof CATEGORIES)[number];
+// Phase 3.2 v2 Path B exit-gate parameters
+const OVERALL_GATE = 0.9;
+const FAT_CATEGORY_GATE = 0.8;
+const FAT_CATEGORY_MIN_FIXTURES = 3;
+
+// Full enum from src/lib/ingestion/classify.ts CLASSIFIED_TYPES.
+// Subfolder names must come from this list.
+const TEN_CATEGORIES = [
+  "invoice",
+  "purchase_order",
+  "change_order",
+  "proposal",
+  "vendor",
+  "budget",
+  "historical_draw",
+  "plan",
+  "contract",
+  "other",
+] as const;
+type Category = (typeof TEN_CATEGORIES)[number];
 
 type Row = {
   category: Category;
@@ -63,23 +98,221 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
   });
 }
 
+function discoverCategories(root: string): Category[] {
+  assert.ok(existsSync(root), `fixture root missing: ${root}`);
+  const subdirs = readdirSync(root, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+
+  const known = new Set<string>(TEN_CATEGORIES);
+  const unknown = subdirs.filter((d) => !known.has(d));
+  assert.ok(
+    unknown.length === 0,
+    `fixture subfolder(s) not in TEN_CATEGORIES enum: ${unknown.join(", ")}. ` +
+      "Either rename to match an enum value or add the value to TEN_CATEGORIES + the classifier prompt."
+  );
+
+  return subdirs as Category[];
+}
+
+function discoverPdfs(catDir: string): string[] {
+  return readdirSync(catDir)
+    .filter((f) => f.toLowerCase().endsWith(".pdf"))
+    .sort();
+}
+
+function escapePipe(s: string): string {
+  return s.replace(/\|/g, "\\|");
+}
+
+function writeMarkdownReport(args: {
+  rows: Row[];
+  runStart: Date;
+  runEnd: Date;
+  cacheStats: { total: number; hits: number; firstHitIdx: number | null } | null;
+}) {
+  const { rows, runStart, runEnd, cacheStats } = args;
+
+  const total = rows.length;
+  const passed = rows.filter((r) => r.pass).length;
+  const overallAcc = total > 0 ? passed / total : 0;
+
+  const categoriesPresent = Array.from(new Set(rows.map((r) => r.category))).sort() as Category[];
+  type CatStat = {
+    cat: Category;
+    n: number;
+    pass: number;
+    pct: number;
+    fat: boolean;
+    gatePass: boolean;
+    investigate: boolean;
+  };
+  const catStats: CatStat[] = categoriesPresent.map((cat) => {
+    const cr = rows.filter((r) => r.category === cat);
+    const n = cr.length;
+    const pass = cr.filter((r) => r.pass).length;
+    const fat = n >= FAT_CATEGORY_MIN_FIXTURES;
+    const pct = n > 0 ? pass / n : 0;
+    const gatePass = !fat || pct >= FAT_CATEGORY_GATE;
+    const investigate = !fat && pass < n; // thin category with at least one miss
+    return { cat, n, pass, pct, fat, gatePass, investigate };
+  });
+
+  // Categories absent from fixtures but in the enum — fixture top-up needed.
+  const missingCats = TEN_CATEGORIES.filter(
+    (c) => !categoriesPresent.includes(c)
+  );
+
+  const overallGatePass = overallAcc >= OVERALL_GATE;
+  const fatGatePass = catStats.every((s) => s.gatePass);
+  const investigateRows = rows.filter((r) =>
+    catStats.find((s) => s.cat === r.category && s.investigate && !r.pass)
+  );
+
+  mkdirSync(RESULTS_DIR, { recursive: true });
+
+  const lines: string[] = [];
+  lines.push(`# Phase 3.2 v2 — classifier eval results`);
+  lines.push("");
+  lines.push(`Run window: ${runStart.toISOString()} → ${runEnd.toISOString()}`);
+  lines.push(`Fixture root: \`${FIXTURE_ROOT}\` (gitignored, real Ross Built docs)`);
+  lines.push(`Total fixtures: ${total}`);
+  lines.push(`Overall accuracy: ${passed} / ${total} = ${(overallAcc * 100).toFixed(1)}%`);
+  lines.push("");
+  lines.push("## Exit gate status (Path B)");
+  lines.push("");
+  lines.push(`| Gate | Threshold | Actual | Status |`);
+  lines.push(`|---|---|---|---|`);
+  lines.push(
+    `| Overall accuracy | ≥ ${(OVERALL_GATE * 100).toFixed(0)}% | ${(overallAcc * 100).toFixed(1)}% | ${overallGatePass ? "PASS" : "FAIL"} |`
+  );
+  lines.push(
+    `| Per-category accuracy (fat ≥${FAT_CATEGORY_MIN_FIXTURES}) | ≥ ${(FAT_CATEGORY_GATE * 100).toFixed(0)}% each | see table | ${fatGatePass ? "PASS" : "FAIL"} |`
+  );
+  lines.push(
+    `| Thin-category misses | flagged for investigate | ${investigateRows.length} flagged | ${investigateRows.length === 0 ? "no investigation needed" : "INVESTIGATE"} |`
+  );
+  lines.push("");
+
+  lines.push("## Per-category accuracy");
+  lines.push("");
+  lines.push(`| Category | Fixtures | Pass | % | Tier | Status |`);
+  lines.push(`|---|---|---|---|---|---|`);
+  for (const s of catStats) {
+    const tier = s.fat ? "fat" : "thin";
+    const status = s.fat
+      ? s.gatePass
+        ? "PASS"
+        : `FAIL (<${(FAT_CATEGORY_GATE * 100).toFixed(0)}%)`
+      : s.investigate
+        ? "INVESTIGATE — insufficient sample"
+        : "PASS (thin, all-pass)";
+    lines.push(
+      `| \`${s.cat}\` | ${s.n} | ${s.pass} | ${(s.pct * 100).toFixed(1)}% | ${tier} | ${status} |`
+    );
+  }
+  lines.push("");
+
+  if (missingCats.length > 0) {
+    lines.push("## Fixture top-up needed");
+    lines.push("");
+    lines.push("Categories in the enum with zero fixtures in this run:");
+    lines.push("");
+    for (const c of missingCats) lines.push(`- \`${c}\` — 0 fixtures`);
+    lines.push("");
+    lines.push(
+      `Categories with <${FAT_CATEGORY_MIN_FIXTURES} fixtures (thin tier — exit gate cannot apply per-category 80% threshold):`
+    );
+    lines.push("");
+    for (const s of catStats.filter((s) => !s.fat)) {
+      lines.push(`- \`${s.cat}\` — ${s.n} fixture(s)`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Per-fixture results");
+  lines.push("");
+  lines.push(`| Expected | Actual | Pass | Confidence | ms | Filename | Notes |`);
+  lines.push(`|---|---|---|---|---|---|---|`);
+  for (const r of rows) {
+    const note = r.error
+      ? escapePipe(`ERROR: ${r.error}`)
+      : !r.pass && catStats.find((s) => s.cat === r.category && !s.fat)
+        ? "INVESTIGATE — thin category miss"
+        : "";
+    lines.push(
+      `| \`${r.expected}\` | \`${r.actual}\` | ${r.pass ? "PASS" : "FAIL"} | ${r.confidence.toFixed(2)} | ${r.ms} | ${escapePipe(r.filename)} | ${note} |`
+    );
+  }
+  lines.push("");
+
+  lines.push("## Confusion matrix");
+  lines.push("");
+  const actualLabels = Array.from(new Set(rows.map((r) => r.actual))).sort();
+  const headerCells = ["expected ↓ / actual →", ...actualLabels.map((a) => `\`${a}\``)];
+  lines.push("| " + headerCells.join(" | ") + " |");
+  lines.push("|" + headerCells.map(() => "---").join("|") + "|");
+  for (const cat of categoriesPresent) {
+    const cells = [`\`${cat}\``];
+    for (const a of actualLabels) {
+      const n = rows.filter((r) => r.category === cat && r.actual === a).length;
+      cells.push(String(n));
+    }
+    lines.push("| " + cells.join(" | ") + " |");
+  }
+  lines.push("");
+
+  if (cacheStats) {
+    lines.push("## Cache-hit verification");
+    lines.push("");
+    lines.push(`| Metric | Value |`);
+    lines.push(`|---|---|`);
+    lines.push(`| classifier rows this run | ${cacheStats.total} |`);
+    lines.push(`| rows with cache_read_input_tokens > 0 | ${cacheStats.hits} |`);
+    lines.push(
+      `| first cache hit row index | ${cacheStats.firstHitIdx === null ? "n/a" : cacheStats.firstHitIdx} |`
+    );
+    lines.push(
+      `| status | ${cacheStats.hits > 0 ? "PASS (≥1 hit required)" : "FAIL — caching not working"} |`
+    );
+    lines.push("");
+  }
+
+  if (investigateRows.length > 0) {
+    lines.push("## Investigate — thin-category misses");
+    lines.push("");
+    lines.push(
+      "Per Path B: thin categories (<3 fixtures) cannot trigger the per-category 80% gate, but any miss must be investigated against the prompt — not excused as sample-size noise."
+    );
+    lines.push("");
+    for (const r of investigateRows) {
+      lines.push(`- **\`${r.category}\`**: \`${r.filename}\` → got \`${r.actual}\` (conf ${r.confidence.toFixed(2)}). Inspect classifier prompt for the relevant signal.`);
+    }
+    lines.push("");
+  }
+
+  writeFileSync(RESULTS_FILE, lines.join("\n"), "utf8");
+  console.log(`wrote ${RESULTS_FILE}`);
+}
+
 async function main() {
-  // Import after dotenv so the SDK has its API key.
   const { classifyDocument } = await import("../src/lib/ingestion/classify");
   const { createClient } = await import("@supabase/supabase-js");
 
-  assert.ok(existsSync(FIXTURE_ROOT), `fixture root missing: ${FIXTURE_ROOT}`);
+  const categories = discoverCategories(FIXTURE_ROOT);
+  console.log(`discovered ${categories.length} categor${categories.length === 1 ? "y" : "ies"}: ${categories.join(", ")}`);
 
   const runStart = new Date();
   const rows: Row[] = [];
 
-  for (const cat of CATEGORIES) {
+  for (const cat of categories) {
     const dir = join(FIXTURE_ROOT, cat);
-    assert.ok(existsSync(dir), `fixture dir missing: ${dir}`);
-    const files = readdirSync(dir)
-      .filter((f) => f.toLowerCase().endsWith(".pdf"))
-      .sort();
-    assert.ok(files.length > 0, `${cat} should have at least 1 pdf fixture, found 0`);
+    const files = discoverPdfs(dir);
+    if (files.length === 0) {
+      console.log(`SKIP  ${cat} (no .pdf fixtures)`);
+      continue;
+    }
     for (const filename of files) {
       const buf = readFileSync(join(dir, filename));
       const t0 = Date.now();
@@ -90,7 +323,7 @@ async function main() {
             {
               org_id: ORG_ID,
               user_id: null,
-              metadata: { source: "classifier-eval", fixture: `${cat}/${filename}` },
+              metadata: { source: "classifier-eval-v2", fixture: `${cat}/${filename}` },
             }
           ),
           CALL_TIMEOUT_MS,
@@ -109,7 +342,7 @@ async function main() {
         });
         const mark = pass ? "PASS" : "FAIL";
         console.log(
-          `${mark}  ${cat.padEnd(8)} → ${result.classified_type.padEnd(16)} conf=${result.classification_confidence
+          `${mark}  ${cat.padEnd(16)} → ${result.classified_type.padEnd(16)} conf=${result.classification_confidence
             .toFixed(2)
             .padStart(4)} ${String(ms).padStart(5)}ms  ${filename}`
         );
@@ -126,31 +359,51 @@ async function main() {
           ms,
           error: msg,
         });
-        console.log(`FAIL  ${cat.padEnd(8)} → ERROR             conf=0.00 ${String(ms).padStart(5)}ms  ${filename}`);
+        console.log(`FAIL  ${cat.padEnd(16)} → ERROR             conf=0.00 ${String(ms).padStart(5)}ms  ${filename}`);
         console.log(`      ${msg}`);
       }
     }
   }
 
+  const runEnd = new Date();
+
   // ── Summary ────────────────────────────────────────────────────
   const total = rows.length;
   const passed = rows.filter((r) => r.pass).length;
-  const accuracy = total > 0 ? passed / total : 0;
-  const gatePass = accuracy >= ACCURACY_GATE;
+  const overallAcc = total > 0 ? passed / total : 0;
+  const overallGatePass = overallAcc >= OVERALL_GATE;
 
   console.log("");
   console.log("── Summary ─────────────────────────────────────────");
-  console.log(`accuracy: ${passed}/${total} = ${(accuracy * 100).toFixed(1)}%`);
-  console.log(`gate ≥${(ACCURACY_GATE * 100).toFixed(0)}%: ${gatePass ? "PASS" : "FAIL"}`);
+  console.log(`accuracy: ${passed}/${total} = ${(overallAcc * 100).toFixed(1)}%`);
+  console.log(`overall gate ≥${(OVERALL_GATE * 100).toFixed(0)}%: ${overallGatePass ? "PASS" : "FAIL"}`);
 
   // ── Per-category ───────────────────────────────────────────────
   console.log("");
   console.log("── Per-category accuracy ───────────────────────────");
-  for (const cat of CATEGORIES) {
-    const catRows = rows.filter((r) => r.category === cat);
-    const catPassed = catRows.filter((r) => r.pass).length;
-    const catPct = catRows.length > 0 ? (catPassed / catRows.length) * 100 : 0;
-    console.log(`${cat.padEnd(10)} ${catPassed}/${catRows.length} (${catPct.toFixed(1)}%)`);
+  let fatGatePass = true;
+  let investigateCount = 0;
+  for (const cat of categories) {
+    const cr = rows.filter((r) => r.category === cat);
+    if (cr.length === 0) continue;
+    const cp = cr.filter((r) => r.pass).length;
+    const pct = cp / cr.length;
+    const fat = cr.length >= FAT_CATEGORY_MIN_FIXTURES;
+    let status: string;
+    if (fat) {
+      const ok = pct >= FAT_CATEGORY_GATE;
+      status = ok ? "PASS" : `FAIL (<${(FAT_CATEGORY_GATE * 100).toFixed(0)}%)`;
+      if (!ok) fatGatePass = false;
+    } else {
+      const miss = cr.length - cp;
+      if (miss > 0) {
+        status = `INVESTIGATE (${miss} miss, thin sample)`;
+        investigateCount += miss;
+      } else {
+        status = "PASS (thin, all-pass)";
+      }
+    }
+    console.log(`${cat.padEnd(16)} ${cp}/${cr.length} (${(pct * 100).toFixed(1)}%) ${fat ? "fat " : "thin"} ${status}`);
   }
 
   // ── Confusion matrix ───────────────────────────────────────────
@@ -158,10 +411,10 @@ async function main() {
   console.log("── Confusion matrix (row=expected, col=actual) ─────");
   const actualLabels = Array.from(new Set(rows.map((r) => r.actual))).sort();
   const COL_WIDTH = 14;
-  const header = ["expected".padEnd(12), ...actualLabels.map((a) => a.padEnd(COL_WIDTH))].join("");
+  const header = ["expected".padEnd(16), ...actualLabels.map((a) => a.padEnd(COL_WIDTH))].join("");
   console.log(header);
-  for (const cat of CATEGORIES) {
-    const line = [cat.padEnd(12)];
+  for (const cat of categories) {
+    const line = [cat.padEnd(16)];
     for (const a of actualLabels) {
       const n = rows.filter((r) => r.category === cat && r.actual === a).length;
       line.push(String(n).padEnd(COL_WIDTH));
@@ -174,6 +427,7 @@ async function main() {
   console.log("── Cache-hit verification ──────────────────────────");
   const sbUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  let cacheStats: { total: number; hits: number; firstHitIdx: number | null } | null = null;
   let cachePass = false;
   if (!sbUrl || !sbKey) {
     console.log("SKIP  no supabase env vars — cache check skipped");
@@ -200,30 +454,46 @@ async function main() {
       });
       console.log(`classifier usage rows this run:         ${usageRows.length}`);
       console.log(`rows with cache_read_input_tokens > 0:  ${withCacheRead.length}`);
+      let firstHitIdx: number | null = null;
       if (withCacheRead.length === 0) {
         console.log("FAIL  no cache hits — prompt cache is not working");
       } else {
-        const firstHitIdx = usageRows.findIndex((r) => {
+        firstHitIdx = usageRows.findIndex((r) => {
           const raw = (r.metadata ?? {}) as { cache_read_input_tokens?: unknown };
           return Number(raw.cache_read_input_tokens ?? 0) > 0;
         });
         console.log(`first cache hit at row index:           ${firstHitIdx}`);
         cachePass = true;
       }
+      cacheStats = { total: usageRows.length, hits: withCacheRead.length, firstHitIdx };
     }
   }
 
-  // ── Exit ────────────────────────────────────────────────────────
+  // ── Write structured report for QA ────────────────────────────
   console.log("");
-  const allPass = gatePass && cachePass;
+  writeMarkdownReport({ rows, runStart, runEnd, cacheStats });
+
+  // ── Exit ──────────────────────────────────────────────────────
+  console.log("");
+  const allPass = overallGatePass && fatGatePass && cachePass;
   if (!allPass) {
     const reasons: string[] = [];
-    if (!gatePass) reasons.push(`accuracy ${(accuracy * 100).toFixed(1)}% < ${(ACCURACY_GATE * 100).toFixed(0)}%`);
+    if (!overallGatePass)
+      reasons.push(`overall ${(overallAcc * 100).toFixed(1)}% < ${(OVERALL_GATE * 100).toFixed(0)}%`);
+    if (!fatGatePass) reasons.push("≥1 fat category below 80%");
     if (!cachePass) reasons.push("cache verification failed");
     console.error(`${reasons.length} failure(s): ${reasons.join(", ")}`);
+    if (investigateCount > 0)
+      console.error(`(also: ${investigateCount} thin-category miss(es) to investigate — see report)`);
     process.exit(1);
   }
-  console.log(`${total} fixture(s) classified; accuracy ${(accuracy * 100).toFixed(1)}%; cache verified`);
+  if (investigateCount > 0) {
+    console.log(
+      `${total} fixture(s); accuracy ${(overallAcc * 100).toFixed(1)}%; cache verified; ${investigateCount} thin-category miss(es) flagged for investigation`
+    );
+  } else {
+    console.log(`${total} fixture(s); accuracy ${(overallAcc * 100).toFixed(1)}%; cache verified`);
+  }
   console.log(`${total} test(s) passed`);
 }
 

--- a/qa-reports/qa-branch3-phase3.2-v2-dogfood.md
+++ b/qa-reports/qa-branch3-phase3.2-v2-dogfood.md
@@ -1,0 +1,116 @@
+# Phase 3.2 v2 — dogfood report (classifier-direct mode)
+
+Run window: 2026-04-27T16:33:37.786Z → 2026-04-27T16:33:56.323Z
+Mode: **classifier-direct**. Skips /api/ingest plumbing — see §Mode below.
+Fixture root: `__tests__/fixtures/classifier/.local/dogfood` (gitignored — real Ross Built docs only)
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total documents | 6 |
+| Successful classifications | 6 |
+| Failed (classifier error) | 0 |
+| Low-confidence rows (<0.7) | 0 |
+| Avg latency | 3059 ms |
+| Cache-hit rate (api_usage) | 83.3% |
+
+## Mode — why classifier-direct, not /api/ingest
+
+The original dogfood plan POSTed each PDF to `/api/ingest` with Jake's
+authenticated session cookie. Supabase splits long auth tokens into
+chunked cookies (`name.0`, `name.1`); when copied from Chrome DevTools
+and pasted, the chunk boundary loses a few separator characters that
+aren't recoverable from the visible text — the SSR base64-URL decoder
+then errors with `Invalid UTF-8 sequence`.
+
+Rather than burn another cycle on cookie extraction, this run calls
+`classifyDocument()` directly on every PDF in the dogfood folder.
+
+**What this proves:** the classifier classifies real, unseen Ross Built
+documents correctly (no overfitting to the eval fixture set).
+
+**What this skips:** the `/api/ingest` plumbing — multipart upload,
+`document_extractions` insert/update with `invoice_id=null`, soft-delete
+on classifier failure. That surface is covered separately by the 17
+static fences in `__tests__/api-ingest.test.ts` and by future manual
+curl-with-cookie when a clean session cookie is available.
+
+## What was NOT tested
+
+The /api/ingest HTTP route did not execute end-to-end against real
+session auth in this dogfood. Specifically, the following surfaces have
+**no live runtime evidence** in v2:
+
+1. **The /api/ingest HTTP route under real session auth.** No real
+   browser cookie has been validated against `getCurrentMembership()`
+   during this phase. The auth gate's correct *shape* is enforced
+   structurally (static fence #4: `getCurrentMembership` import; #5:
+   not `requireOrgId`; #7: 401 on null membership), but the runtime
+   path was not exercised end-to-end.
+2. **DB writes through the live route flow.** The route's
+   `INSERT document_extractions` (with `invoice_id=null`,
+   `verification_status='pending'`) and the post-classify `UPDATE` of
+   `classified_type` + `classification_confidence` are structurally
+   verified by static fences #8, #9, #11, but no real row has been
+   created via the HTTP path.
+3. **Org-scoping enforcement under real auth.** The structural fence
+   (#11) confirms the route filters `.update()` by
+   `.eq('org_id', membership.org_id)`. The actual cross-tenant
+   protection has not been runtime-tested.
+4. **Storage upload to `{org_id}/ingest/...`.** The path-templating is
+   structurally verified (fence #12), but no file has actually been
+   pushed to the `invoice-files` bucket via the route.
+5. **Soft-delete-on-failure path.** Fence #15 confirms the code is
+   present; not exercised at runtime since classifier failures didn't
+   occur in eval or dogfood.
+
+### What WAS tested
+
+- **Classifier on 36 eval fixtures** — `RUN_CLASSIFIER_EVAL=1 npm test`
+  passes 36/36 = 100% across 9 of 10 categories (eval report
+  `qa-reports/.eval/phase3.2-v2-eval.md`).
+- **Classifier on 6 novel real-world docs** — this dogfood, 6/6 = 100%
+  via `classifyDocument()` direct.
+- **Route structure** — 17 static structural fences in
+  `__tests__/api-ingest.test.ts`, all PASS.
+- **Schema readiness** — migration 00081 verified on dev (131 rows, 0
+  CHECK violations).
+
+### Implication for cutover
+
+The first real-world HTTP test of `/api/ingest` will happen on the
+first authenticated upload after merge. Watch the first dogfood-style
+upload's behavior carefully:
+
+- Confirm `document_extractions` row appears with `invoice_id=null`,
+  `target_entity_*` NULL, `verification_status='pending'`.
+- Confirm `raw_pdf_url` points at `{org_id}/ingest/{ts}_{name}.pdf`.
+- Confirm `classified_type` + `classification_confidence` populate
+  after the classifier returns.
+- Confirm a deliberate failure (e.g., upload a 0-byte file) triggers
+  the soft-delete path and returns a structured 500.
+
+If any of those misbehave, raise an issue and the rollback is
+reverting commit `9a58793`.
+
+## Per-fixture results
+
+**Jake fills `Expected` and `Pass/fail` after the run.** Use one of the
+ten enum values for Expected: `invoice`, `purchase_order`, `change_order`,
+`proposal`, `vendor`, `budget`, `historical_draw`, `plan`, `contract`, `other`.
+
+| # | Filename | Size (KB) | Pages | Classified | Confidence | Cache hit | Latency (ms) | Expected | Pass/fail |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | 52fdse.pdf | 103.7 | 1 | `purchase_order` | 1.00 | no | 2581 | `purchase_order` | **PASS** |
+| 2 | 534gf.pdf | 122.7 | 1 | `change_order` | 0.98 | yes | 2877 | `change_order` | **PASS** |
+| 3 | 853 N Shore - Executed Construction Agreement.pdf | 247.9 | 10 | `contract` | 0.98 | yes | 3647 | `contract` | **PASS** |
+| 4 | Clark Unity of title_Document 1_AGREEMENT_20240124.pdf | 54.7 | 1 | `other` | 0.95 | yes | 2174 | `other` | **PASS** |
+| 5 | Crews UDA used for AIA.pdf | 205.6 | 13 | `budget` | 0.95 | yes | 3905 | `budget` | **PASS** (see disposition note) |
+| 6 | REVISED ESTIMATE 21-496 ROSS BUILT CONSTRUCTION CLARK RESIDENCE.pdf | 303.0 | 3 | `proposal` | 0.92 | yes | 3168 | `proposal` | **PASS** |
+
+**Overall: 6/6 = 100% on novel real-world Ross Built documents.**
+
+### Disposition note — fixture #5 (`Crews UDA used for AIA.pdf`)
+
+Ambiguous on filename alone (`UDA used for AIA` reads like it could be a draw). UDA refers to UDA Construction Suite, an estimating package; the PDF is the *source budget* exported from UDA that was later reformatted into AIA G702/G703 for billing. It is the budget input, not a draw output. Classifier returned `budget`, which is the correct disposition. The 0.95 confidence is appropriate — high but not 1.0, reflecting the genuine ambiguity in the filename.

--- a/qa-reports/qa-branch3-phase3.2-v2.md
+++ b/qa-reports/qa-branch3-phase3.2-v2.md
@@ -1,0 +1,356 @@
+# Branch 3 Phase 3.2 v2 — Final QA
+
+**Phase:** 3.2 v2 — Document classifier production wiring + full category coverage
+**Scope one-liner:** Ship `/api/ingest` route, full 10-category eval coverage, and the schema relaxation that v1's Path Z deferred. Legacy `/api/invoices/parse` flow 100% untouched.
+**Branch:** `phase-3.2-v2`
+**HEAD before phase:** `c885ce3` (Merge PR #23 — phase-a-lockdown)
+**HEAD after phase:** see §11
+**v1 reference:** `qa-reports/qa-branch3-phase3.2.md` (HEAD `975e06e`, 2026-04-24)
+**Plan-doc reference:** `docs/nightwork-rebuild-plan.md:5911–6009`
+**Date:** 2026-04-27
+**Author:** Claude Code (under Jake Ross)
+
+---
+
+## 1. Summary
+
+Phase 3.2 v2 closes everything v1 deferred under Path Z. v1 shipped infrastructure (classifier library + `classification_confidence` column + 4-category eval) but skipped `/api/ingest` because `document_extractions.invoice_id` was `NOT NULL`. v2 unblocks that with migration 00081 (Jake-approved Path A, Section-4 STOP lifted), wires the route, and re-runs the eval against the full 10-category enum.
+
+| Item | v1 status | v2 status |
+|---|---|---|
+| Classifier library | shipped (`src/lib/claude/classify-document.ts`) | **relocated** to plan-doc target `src/lib/ingestion/classify.ts` (Step 1) |
+| `classification_confidence` column | shipped (migration 00079) | preserved unchanged |
+| `invoice_id` nullability | NOT NULL (blocker) | **nullable + target-aware CHECK** (migration 00081, Step 1.5) |
+| `/api/ingest` route | **deferred** (Path Z) | **shipped** with 17 structural fences (Step 2) |
+| Classifier eval | 4 categories, 15 fixtures, 100% (after 2 re-labels) | **9 categories, 36 fixtures, 100%, zero re-labels** (Step 3) |
+| Prompt iteration | N/A | **N/A** (Step 4 skipped — every category passed first try) |
+| Cache-hit verification | 13/15 hits | **35/36 hits**, first hit at idx 1 |
+| QA report | this doc's predecessor | this doc |
+
+**Headline:** classifier ships production-ready under parallel-deploy framing. UI integration is Phase 3.10 scope; extraction pipelines for non-invoice types are Phases 3.3–3.8.
+
+---
+
+## 2. Exit gate — verbatim from plan §5985–6007
+
+| # | Plan exit-criterion item | Status | Evidence |
+|---|---|---|---|
+| 1 | Classifier achieves ≥90% accuracy on 20-document test set (5 of each major type) | **PASS, exceeded** | 36/36 = 100.0% across 9 categories. 36 fixtures > spec's 20. Per Path B (Jake's prompt 153), per-fixture results in §5; per-category in §6. |
+| 2 | Universal `/api/ingest` accepts file → creates `document_extraction` row with `classified_type` | **PASS** | Route at `src/app/api/ingest/route.ts` (commit `9a58793`). 17/17 structural fences in `__tests__/api-ingest.test.ts` PASS. Insert + classify + UPDATE flow per Resolved Decision in plan §5941–5944. |
+| 3 | Confidence score recorded in `classification_confidence NUMERIC(5,4)`; low-confidence (<0.70) flagged for manual type selection | **PASS (writing); UI deferred to 3.10 per spec** | Column written by route on success (`src/app/api/ingest/route.ts:75-89`). Queryable via `WHERE classification_confidence < 0.70`. UI surface explicitly Phase 3.10 per Jake's prompt 153 boundary. |
+| 4 | Test runner subagent: all classifier tests PASS | **PASS** | `npm test` green (47 files). Eval `RUN_CLASSIFIER_EVAL=1 npm test` reports `36 test(s) passed`. |
+| 5 | Classifier system prompt cached via prompt caching (verify cache hit on second call via `api_usage` metadata) | **PASS** | 35/36 cache hits, first hit at row index 1. Cache verification table in §7. |
+| 6 | QA report with sample classifications for each type, including per-fixture {source, filename, expected, actual, confidence, pass/fail} | **PASS** | This document, §5. All 36 fixtures real Ross Built docs (zero synthetic), gitignored under `__tests__/fixtures/classifier/.local/`. |
+
+**All 6 exit-gate items PASS.**
+
+---
+
+## 3. v1 → v2 file location diff (Step 1 relocation)
+
+| Path | v1 | v2 |
+|---|---|---|
+| Classifier library | `src/lib/claude/classify-document.ts` | `src/lib/ingestion/classify.ts` |
+| Classifier test harness | `__tests__/document-classifier.test.ts` (4-category) | same path, fully rewritten (10-category, dynamic fixture discovery) |
+| Migration | `00079_add_classification_confidence.sql` (column add) | preserved unchanged |
+| New migration | — | `00081_document_extractions_invoice_id_nullable.sql` |
+| New route | — | `src/app/api/ingest/route.ts` |
+| New test | — | `__tests__/api-ingest.test.ts` |
+| New eval-output (gitignored) | — | `qa-reports/.eval/phase3.2-v2-eval.md` |
+
+The relocation is the plan-doc target (§5917): `src/lib/ingestion/classify.ts`. v1 placed the classifier under `src/lib/claude/` to live alongside `parse-invoice.ts`; v2 sets up the `src/lib/ingestion/` namespace ahead of Phases 3.3–3.8 type-specific extractors.
+
+Imports updated:
+- `__tests__/document-classifier.test.ts:68` — dynamic import path
+- Console-warn log tag `[classify-document]` → `[ingestion/classify]`
+
+No production code import sites needed updating — v1 already had no production callers (Path Z).
+
+---
+
+## 4. Migration numbering — historical reality
+
+Two slot-allocation observations worth recording for future migration audits.
+
+| Slot | Plan-doc anticipated | Actual | Why |
+|---|---|---|---|
+| 00078 | classification_confidence column (per preflight §8) | `00078_backfill_invoice_allocations_from_line_items` | Slot 00078 was consumed by an unrelated invoice_allocations backfill before classifier work resumed. v1 rolled forward to 00079 for the column add. Documented as historical reality per Jake's prompt 153 — no schema change needed. |
+| 00079 | unallocated | `00079_add_classification_confidence` | v1's actual classification_confidence column add (Phase 3.2 v1, commit `975e06e`). |
+| 00080 | nullable invoice_id (Jake's prompt 154 spec) | `00080_enable_rls_core_tables` | Slot 00080 was consumed by Phase A's RLS-enable migration (commit `37f0891`, PR #23, merged 2026-04-27 — the same merge that became this v2 phase's HEAD-before). v2 rolled forward to 00081. |
+| 00081 | — | `00081_document_extractions_invoice_id_nullable` | v2's actual nullable-invoice_id migration (Phase 3.2 v2 Step 1.5, commit `1c05c55`). |
+
+No schema changes other than 00081 in v2.
+
+### Migration 00081 — detail
+
+```sql
+ALTER TABLE public.document_extractions
+  ALTER COLUMN invoice_id DROP NOT NULL;
+
+ALTER TABLE public.document_extractions
+  ADD CONSTRAINT document_extractions_invoice_id_required_when_invoice_target
+  CHECK (target_entity_type IS DISTINCT FROM 'invoice' OR invoice_id IS NOT NULL);
+```
+
+- Pre-deploy verification (rows where `target_entity_type='invoice' AND invoice_id IS NULL`): 0 ✅
+- Post-apply state on dev: `invoice_id` nullable=YES, CHECK present, 131 rows / 0 violations
+- Down migration: drops the CHECK + re-asserts NOT NULL. Will fail if non-invoice rows exist by then — a down migration must not silently discard data.
+- Approved by Jake (prompt 154): "v1's Path Z deferral root cause… Phases 3.3–3.8 require this nullability anyway. Doing it now in v2 is correct sequencing."
+- Section-4 STOP ("schema changes barred") was explicitly lifted for this migration only.
+
+---
+
+## 5. Per-fixture eval results
+
+Run window: `2026-04-27T15:49:55.466Z → 2026-04-27T15:52:11.946Z` (UTC)
+Fixture root: `__tests__/fixtures/classifier/.local/` (gitignored, real Ross Built docs)
+Total fixtures: 36
+Source: every fixture is a real Ross Built document. Zero synthetic. Risk R8 mitigated.
+
+| Expected | Actual | Pass | Confidence | ms | Filename |
+|---|---|---|---|---|---|
+| `budget` | `budget` | PASS | 0.92 | 6336 | Drummond - Line Items Cost Coded.pdf |
+| `budget` | `budget` | PASS | 0.95 | 3848 | Fish - Detailed Estimate Report 10-24-23.pdf |
+| `change_order` | `change_order` | PASS | 1.00 | 3412 | drummond co 1.pdf |
+| `change_order` | `change_order` | PASS | 0.98 | 2493 | fish co 1.pdf |
+| `change_order` | `change_order` | PASS | 0.98 | 3629 | fish co 2.pdf |
+| `change_order` | `change_order` | PASS | 0.98 | 2663 | krauss co 1.pdf |
+| `change_order` | `change_order` | PASS | 0.98 | 2554 | pou co 1.pdf |
+| `contract` | `contract` | PASS | 0.98 | 4169 | Drummond Contract-Executed.pdf |
+| `contract` | `contract` | PASS | 0.95 | 3837 | Molinari - Bank Contract.pdf |
+| `contract` | `contract` | PASS | 0.95 | 7293 | Molinari- Signed Contract.pdf |
+| `contract` | `contract` | PASS | 0.98 | 4529 | Ross Built - Ruthven Contract.pdf |
+| `invoice` | `invoice` | PASS | 0.95 | 3472 | 10_Home_Depot_Receipts.pdf |
+| `invoice` | `invoice` | PASS | 0.98 | 2360 | INV-108975.pdf |
+| `invoice` | `invoice` | PASS | 1.00 | 2339 | Invoice#523.pdf |
+| `invoice` | `invoice` | PASS | 0.98 | 3657 | Markgraf 03112.pdf |
+| `invoice` | `invoice` | PASS | 0.95 | 3185 | Markgraf 34101.pdf |
+| `invoice` | `invoice` | PASS | 0.98 | 2401 | dewberry_batch_p1_invoice.pdf |
+| `other` | `other` | PASS | 0.98 | 6567 | Dewberry March 2026 Lien Releases.pdf |
+| `other` | `other` | PASS | 0.95 | 2019 | Receipt-2339-6162-9445.pdf |
+| `other` | `other` | PASS | 0.85 | 2741 | Receipt_1182513234.pdf |
+| `plan` | `plan` | PASS | 0.98 | 8377 | Dewberry - Landscaping Drawing 2022.pdf |
+| `proposal` | `proposal` | PASS | 0.92 | 8896 | Dewberry - Gilkey Landscaping 6-5-25 Q.pdf |
+| `proposal` | `proposal` | PASS | 0.95 | 5054 | Dewberry - KL Roof 3-19-25 Q.pdf |
+| `proposal` | `proposal` | PASS | 0.95 | 6029 | Drummond - ML Concrete 5-1-25 SQ Signed.pdf |
+| `proposal` | `proposal` | PASS | 0.92 | 3240 | Drummond - REV Garage doors - Banko 9.26.25.pdf |
+| `proposal` | `proposal` | PASS | 0.95 | 2503 | ROSSBUILT-GAVIN GUEST SUITE.pdf |
+| `purchase_order` | `purchase_order` | PASS | 1.00 | 2159 | drummond po 1.pdf |
+| `purchase_order` | `purchase_order` | PASS | 0.98 | 2603 | fish po 1.pdf |
+| `purchase_order` | `purchase_order` | PASS | 0.98 | 2177 | krauss po 1.pdf |
+| `purchase_order` | `purchase_order` | PASS | 1.00 | 2549 | krauss po 2.pdf |
+| `purchase_order` | `purchase_order` | PASS | 1.00 | 2536 | ruthven po 1.pdf |
+| `vendor` | `vendor` | PASS | 0.98 | 3034 | 20260331110534409.pdf |
+| `vendor` | `vendor` | PASS | 0.98 | 2358 | 2526_TopBuild Corp_Ross Built__26021035642204_570112735790.pdf |
+| `vendor` | `vendor` | PASS | 0.95 | 4940 | Certificate.pdf |
+| `vendor` | `vendor` | PASS | 0.98 | 3296 | Receipt_2025-12-26_160652.pdf |
+| `vendor` | `vendor` | PASS | 0.98 | 3178 | Receipt_2025-12-26_161143.pdf |
+
+**Zero re-labels.** v1's QA flagged 2 fixtures as test-set labeling errors (a landscape drawing and a Home Depot receipt). v2 inherited those re-labeled fixture placements. Every other fixture is in its original location. No new re-labels were applied during this run.
+
+**Confidence range:** 0.85 (one `other` fixture) – 1.00 (POs and one CO). No fixture under 0.70 → no rows that would route to manual type selection in Phase 3.10.
+
+---
+
+## 6. Per-category accuracy
+
+| Category | Fixtures | Pass | % | Tier | Status |
+|---|---|---|---|---|---|
+| `budget` | 2 | 2 | 100.0% | thin | PASS (thin, all-pass) |
+| `change_order` | 5 | 5 | 100.0% | fat | PASS |
+| `contract` | 4 | 4 | 100.0% | fat | PASS |
+| `historical_draw` | 0 | — | — | absent | **fixture top-up needed** |
+| `invoice` | 6 | 6 | 100.0% | fat | PASS |
+| `other` | 3 | 3 | 100.0% | fat | PASS |
+| `plan` | 1 | 1 | 100.0% | thin | PASS (thin, all-pass) |
+| `proposal` | 5 | 5 | 100.0% | fat | PASS |
+| `purchase_order` | 5 | 5 | 100.0% | fat | PASS |
+| `vendor` | 5 | 5 | 100.0% | fat | PASS |
+
+**Path B exit gate (per Jake's prompt 153):**
+
+| Gate | Threshold | Actual | Status |
+|---|---|---|---|
+| Overall accuracy | ≥ 90% | 100.0% | PASS |
+| Per-category accuracy (fat ≥3 fixtures) | ≥ 80% each | 100% on all 6 fat categories | PASS |
+| Thin-category misses | flag any miss for INVESTIGATE | 0 misses | no investigation needed |
+
+### Confusion matrix
+
+Perfect diagonal — zero off-diagonal entries.
+
+| expected ↓ / actual → | `budget` | `change_order` | `contract` | `invoice` | `other` | `plan` | `proposal` | `purchase_order` | `vendor` |
+|---|---|---|---|---|---|---|---|---|---|
+| `budget` | 2 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `change_order` | 0 | 5 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `contract` | 0 | 0 | 4 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `invoice` | 0 | 0 | 0 | 6 | 0 | 0 | 0 | 0 | 0 |
+| `other` | 0 | 0 | 0 | 0 | 3 | 0 | 0 | 0 | 0 |
+| `plan` | 0 | 0 | 0 | 0 | 0 | 1 | 0 | 0 | 0 |
+| `proposal` | 0 | 0 | 0 | 0 | 0 | 0 | 5 | 0 | 0 |
+| `purchase_order` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 5 | 0 |
+| `vendor` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 5 |
+
+---
+
+## 7. Cache-hit verification
+
+| Metric | Value |
+|---|---|
+| classifier `api_usage` rows this run | 36 |
+| rows with `cache_read_input_tokens > 0` | 35 |
+| first cache hit row index | 1 (second fixture) |
+| cache TTL (ephemeral) | 5 minutes |
+| status | **PASS** (gate ≥1 hit; actual 35) |
+
+Steady-state rate of 35/36 = 97.2%. Only the very first call creates the cache entry; calls 2–36 read from it. v1's rerun showed 13/15 = 86.7% with a cold-cache double-miss on calls 1–2; this run is cleaner, likely because it ran end-to-end without an intervening idle period.
+
+Cache metadata is still being logged on every `callClaude()` response (the `src/lib/claude.ts` extension shipped in v1 commit `975e06e`). No new wrapper changes in v2.
+
+---
+
+## 8. Prompt iteration history (Step 4)
+
+**Skipped.** Step 4 was conditional on a fat-category falling below 80%; every fat category landed at 100% on the first run with the v1 prompt unchanged. Zero prompt edits in v2. The only files touched in `src/lib/ingestion/classify.ts` are the rename (Step 1) and the log-tag string update (`[classify-document]` → `[ingestion/classify]`); the `CLASSIFIER_SYSTEM_PROMPT` itself is byte-identical to v1.
+
+---
+
+## 9. /api/ingest integration test results
+
+`__tests__/api-ingest.test.ts` ships **17 static structural fences**. All PASS:
+
+| # | Fence | Status |
+|---|---|---|
+| 1 | route file exists at `src/app/api/ingest/route.ts` | PASS |
+| 2 | classifier exists at post-Step-1 location `src/lib/ingestion/classify.ts` | PASS |
+| 3 | legacy `/api/invoices/parse` route still exists (untouched cutover guarantee) | PASS |
+| 4 | route imports `getCurrentMembership` from `@/lib/org/session` | PASS |
+| 5 | route does NOT use `requireOrgId` (legacy pattern) | PASS |
+| 6 | route imports `classifyDocument` from `@/lib/ingestion/classify` | PASS |
+| 7 | route enforces auth: throws `ApiError` 401 when membership is null | PASS |
+| 8 | route inserts `document_extractions` with `invoice_id=null` | PASS |
+| 9 | route inserts `document_extractions` with `verification_status='pending'` | PASS |
+| 10 | route does NOT set `target_entity_type` or `target_entity_id` at insert time | PASS |
+| 11 | route filters Supabase updates by `org_id` (org scoping) | PASS |
+| 12 | route storage path is org-scoped (prevents cross-tenant overwrite) | PASS |
+| 13 | route returns the contract payload `{extraction_id, classified_type, classification_confidence}` | PASS |
+| 14 | route handles `PlanLimitError` → 429 with structured fields | PASS |
+| 15 | route soft-deletes `document_extractions` row on classifier failure (no `'failed'` enum value) | PASS |
+| 16 | legacy `/api/invoices/parse` route does NOT import the new classifier (cutover boundary) | PASS |
+| 17 | legacy `/api/invoices/parse` route still uses `requireOrgId` (proves v2 did not modify it) | PASS |
+
+### Why static fences and not in-process Next.js handler invocation
+
+Spinning the Next.js route in-process inside the static runner would require synthesizing auth cookies (`getCurrentMembership()` reads from cookies via `createServerClient`). Live happy-path coverage is exercised by `__tests__/document-classifier.test.ts` (`RUN_CLASSIFIER_EVAL=1`) which calls `classifyDocument()` directly against the same 36 real PDFs the route would. The structural fences cover the route's auth, org-scoping, storage-path, contract-payload, and failure-path surfaces; the eval covers the classifier itself. No marginal gain in coupling them into one harness.
+
+---
+
+## 10. Cutover plan — parallel-deploy, dogfood checklist
+
+v2 ships under explicit parallel-deploy framing per Jake's prompt 153:
+
+> "/api/ingest is greenfield, no existing call sites… Legacy /api/invoices/parse 100% untouched."
+> "EXPLICIT BOUNDARY: No UI consumes /api/ingest in v2. It is a backend-only deliverable. UI integration is Phase 3.10 scope."
+
+### Dogfood checklist (Jake-driven, before any Phase 3.10 cutover decision)
+
+- [ ] Run a real Ross Built invoice through `/api/ingest` via curl with a logged-in session cookie. Confirm response payload includes `extraction_id`, `classified_type='invoice'`, `classification_confidence ≥ 0.90`.
+- [ ] Inspect the resulting row: `SELECT id, classified_type, classification_confidence, invoice_id, target_entity_type, target_entity_id, verification_status, raw_pdf_url FROM document_extractions WHERE id = '<extraction_id>';`. Expected: `classified_type='invoice'`, `invoice_id=NULL`, `target_entity_type=NULL`, `target_entity_id=NULL`, `verification_status='pending'`.
+- [ ] Try one PO PDF, one CO PDF, one proposal PDF. Confirm each lands with the correct `classified_type` and the same NULL invariants on `invoice_id`/`target_*`.
+- [ ] Confirm legacy upload path (`/invoices/upload` or wherever `/api/invoices/parse` is called from) still works end-to-end. v2 must not have regressed it.
+- [ ] Spot-check `api_usage`: rows with `function_type='document_classify'` should exist, with sane token counts and cache_read entries on calls after the first.
+- [ ] Look at storage: `{org_id}/ingest/{ts}_{name}.pdf` paths should exist in the `invoice-files` bucket alongside the legacy `{org_id}/uploads/...` paths. They coexist; nothing is in conflict.
+
+### Hard-cutover gate (NOT in v2 scope)
+
+A real cutover from `/api/invoices/parse` to `/api/ingest`-routed extraction requires:
+
+1. **Phase 3.3+ extractors land** for non-invoice types (PO / CO / proposal / vendor / budget / historical_draw / contract / plan / other). Until those exist, classifying a non-invoice document is dead-end work — there's no extractor to dispatch to.
+2. **Phase 3.10 unified `/ingest` UI** so users can upload arbitrary documents.
+3. **Manual type-override surface** for the <0.70 confidence rows (none present in this dataset, but production will produce some eventually).
+4. **`/api/invoices/parse` deprecation plan** — graceful: existing invoice uploads continue working through the legacy path, new uploads route through `/api/ingest`, then legacy retired once metrics show the new path is stable.
+
+None of those are this phase's work.
+
+---
+
+## 11. Open issues / risks for Phase 3.3+
+
+### Fixture top-up needed
+
+The eval covers 9 of 10 enum values. Fixture inventory and target counts:
+
+| Category | Fixtures now | Tier | Action item |
+|---|---|---|---|
+| `historical_draw` | **0** | absent | Need ≥3 fixtures before classifier gates any historical-draw routing in production. AIA G702/G703 PDFs from prior Ross Built draws are the source. |
+| `plan` | 1 | thin | Need ≥2 more fixtures to reach fat-category threshold. Sources: any architectural / civil / MEP / landscape PDFs. |
+| `budget` | 2 | thin | Need ≥1 more to reach fat-category threshold. Source: any internal Ross Built cost-code budget PDF. |
+
+**No category currently fails the gate. The thin/absent categories pass on their existing fixtures (or are skipped). Top-up is a Phase 3.3+ pre-requisite for production-grade per-category measurement, not a v2 blocker.**
+
+### Schema readiness for 3.3–3.8
+
+Migration 00081 (this phase) makes `invoice_id` nullable with `target_entity_type='invoice'` enforcement. Phases 3.3–3.8 will need:
+
+- Foreign-key columns on `document_extractions` for non-invoice target entities (`po_id`, `co_id`, `proposal_id`, `vendor_id`, `budget_id`, `historical_draw_id`)? OR
+- A polymorphic pattern using `target_entity_type` + `target_entity_id` as already designed (UUID with no FK)? The current schema already has `target_entity_id UUID` columns added in Phase 3.1. Each downstream phase decides per-entity whether to add a typed FK column too.
+
+This is a per-phase decision; v2 doesn't pre-commit one way.
+
+### Risk register status
+
+| # | Risk (from preflight §11) | v2 status |
+|---|---|---|
+| R1 | Classification accuracy <90% on 20-doc set | **MITIGATED.** 36/36 = 100% across 9 categories. Six previously unmeasured categories (PO, CO, vendor, budget, contract — and historical_draw still pending) now empirically validated. |
+| R2 | Synthetic fixtures over-fit classifier | **MITIGATED.** Zero synthetic fixtures. All 36 are real Ross Built docs. |
+| R3 | First prompt-caching adopter — cache miss rate uncertain | **MITIGATED.** 35/36 = 97.2% steady-state hit rate. Single cold-cache miss on first call is expected (cache write must commit before subsequent reads). |
+| R4 | Multi-page PDF input tokens spike | **OBSERVED, ACCEPTABLE.** Largest fixture = the landscape drawing (1 page, 8.4s — likely image-heavy). Median ms ~3300. No anomalies. |
+| R5 | `callClaude` `PlanLimitError` surfaces during classify | **HANDLED.** Route maps `PlanLimitError` → 429 with structured fields. Static fence #14 verifies. |
+| R6 | `verification_status` enum 4-value form vs eventual target | **N/A in v2.** Route uses `'pending'`, valid in both current and Amendment-M target shapes. |
+| R7 | `target_entity_type` / `target_entity_id` left NULL by classifier | **CONFIRMED.** Static fence #10 enforces this. Phase 3.3+ owns commit-time population. |
+| R8 | Test fixtures may contain sensitive vendor pricing data | **MITIGATED.** All 36 fixtures gitignored under `.local/`. `.gitignore` already had the entry from v1; v2 added `qa-reports/.eval/` to the same file. |
+
+### New v2 risk
+
+| # | Risk | Severity | Mitigation |
+|---|---|---|---|
+| R9 | Soft-delete-on-classifier-failure leaves orphan storage objects in `invoice-files/{org_id}/ingest/...` | Low | Storage objects accumulate but are never user-visible. A future cleanup job (Phase 3.4 or later) can drop storage paths whose `document_extractions` row has `deleted_at IS NOT NULL` for >30 days. Not a v2 blocker; documented for future ops work. |
+
+---
+
+## 12. Commit log (commits added on `phase-3.2-v2`)
+
+```
+40017fc test(classifier): full 10-category eval coverage
+9a58793 feat(ingestion): /api/ingest route — parallel to invoices/parse
+1c05c55 feat(ingestion): allow nullable invoice_id with target-aware CHECK
+646f2d4 refactor(ingestion): relocate classifier to src/lib/ingestion/classify.ts
+```
+
+The fifth commit is this QA report itself.
+
+**HEAD before:** `c885ce3` (main, Merge PR #23)
+**HEAD after:** see `git log -1 phase-3.2-v2` post this commit.
+
+---
+
+## 13. Build / lint / test status at phase close
+
+| Check | Status | Notes |
+|---|---|---|
+| `npm test` | PASS | 47 test files green |
+| `RUN_CLASSIFIER_EVAL=1 npm test` (eval) | PASS | 36 fixtures, 100% accuracy, cache verified, 0 INVESTIGATE |
+| `npm run lint` | warnings only | No errors. The 4 React-hooks / aria warnings predate Phase 3.2 v2 (live on `main`). v2 introduces zero new lint flags. |
+| `npm run build` | **fails on `/admin` page-data-collection** | **Pre-existing.** Documented at commit `67e463e qa(phase-a): record final gate results — pre-existing lint/build fail`. Verified by `git stash && git checkout main && npm run build` reproducing the same `PageNotFoundError: Cannot find module for page: /admin`. v2's compile of `src/app/api/ingest/route.ts` and `src/lib/ingestion/classify.ts` succeeds; the failure is downstream and unrelated. Phase A's QA owns this. |
+
+---
+
+## 14. Phase 3.2 v2 closure statement
+
+v2 closes the Path-Z gap from v1. The classifier is now production-wired: `/api/ingest` exists, the schema permits the row at insert time, and the eval has empirical evidence on 9 of 10 enum values at 100% accuracy. The only category lacking measurement is `historical_draw` (zero fixtures). Three categories (`historical_draw`, `plan`, `budget`) are below the 3-fixture fat threshold and are flagged for top-up before Phase 3.3+ relies on per-category gates.
+
+**Parallel-deploy boundary held**: legacy `/api/invoices/parse` is byte-identical to its pre-v2 form. Static fence #17 enforces this assertion in CI going forward.
+
+**No UI surface in v2**: per Jake's prompt 153 explicit boundary, `/api/ingest` is backend-only. Phase 3.10 owns UI integration.
+
+**Phase 3.2 v2 is closed. Production wiring complete. Ready for draft PR + dogfood by Jake before any cutover decision.**

--- a/qa-reports/qa-branch3-phase3.2-v2.md
+++ b/qa-reports/qa-branch3-phase3.2-v2.md
@@ -341,7 +341,26 @@ The fifth commit is this QA report itself.
 | `npm test` | PASS | 47 test files green |
 | `RUN_CLASSIFIER_EVAL=1 npm test` (eval) | PASS | 36 fixtures, 100% accuracy, cache verified, 0 INVESTIGATE |
 | `npm run lint` | warnings only | No errors. The 4 React-hooks / aria warnings predate Phase 3.2 v2 (live on `main`). v2 introduces zero new lint flags. |
-| `npm run build` | **fails on `/admin` page-data-collection** | **Pre-existing.** Documented at commit `67e463e qa(phase-a): record final gate results — pre-existing lint/build fail`. Verified by `git stash && git checkout main && npm run build` reproducing the same `PageNotFoundError: Cannot find module for page: /admin`. v2's compile of `src/app/api/ingest/route.ts` and `src/lib/ingestion/classify.ts` succeeds; the failure is downstream and unrelated. Phase A's QA owns this. |
+| `npm run build` | PASS | Exit 0. See §13.1 below for the corrected story behind this row. |
+
+### 13.1 Build status — correction to the original claim
+
+**Original claim in this row (before correction commit):**
+
+> `npm run build` fails on `/admin` page-data-collection. Pre-existing on `main` since Phase A (commit `67e463e`).
+
+**Reality (verified after dogfood landed):**
+
+The original claim was wrong about both the symptom and the cause.
+
+- **Symptom**: there is no `/admin` build error. `npm run build` on `main` (HEAD `c885ce3`) succeeds with exit 0 when `.next/` is clean and no concurrent `next dev` is running.
+- **Cause of what I originally observed**: almost certainly `.next/` cache corruption from running `npm run dev` and `npm run build` concurrently during the v2 work. With the dev server killed and `.next/` removed, both `main` and `phase-3.2-v2` build cleanly.
+- **The actual build failure** I saw on `phase-3.2-v2` after committing the dogfood scripts was a TypeScript error in `scripts/dogfood-ingest.ts:89` (Buffer→Blob compatibility under Node 24's stricter types) introduced in commit `5bf9cdf`. Fixed in commit `ed1f39a`: wrap with `new Uint8Array(buf)` in the Blob constructor.
+- **A second related break** was a fixture-discovery assertion in the eval harness — adding the `dogfood/` directory under `__tests__/fixtures/classifier/.local/` triggered the dynamic-discovery's "unknown category" assertion. Fixed in commit `bb4be24`: introduce a `SKIPPED_DIRS` set so intentionally-non-category subdirs (initial entry: `dogfood`; pattern open for future names like `experiments`/`archive`) are filtered before the assertion runs.
+
+**What was NOT a real bug**: `/admin`. No fix to that directory was warranted; the `fix-admin-build` branch envisioned in the original plan was abandoned without commits because the premise was wrong.
+
+**Audit trail discipline**: the original §13 row was preserved in the git history (this file at the previous commit retains the wrong claim). The correction is a forward-only edit, no force-push or amend, so the chain shows the false claim → its discovery → the fix → this correction. That's the spirit of R.12: QA reports document what was true at a point in time AND the corrections when reality diverges.
 
 ---
 

--- a/scripts/dogfood-classify-direct.ts
+++ b/scripts/dogfood-classify-direct.ts
@@ -1,0 +1,280 @@
+/**
+ * Phase 3.2 v2 — fallback dogfood when /api/ingest auth cookie is unworkable.
+ *
+ * The original dogfood-ingest.ts script POSTs each PDF to /api/ingest,
+ * which requires a real authenticated session cookie. When Jake's
+ * Supabase chunked auth cookie can't be reliably reconstructed from a
+ * paste (the chunk boundary in DevTools collapses certain characters),
+ * this script provides an end-around: call classifyDocument() directly
+ * on every PDF in the dogfood folder.
+ *
+ * What this proves vs what it skips:
+ *   PROVES   — classifier handles docs not in the eval fixture set
+ *              (no overfitting); per-doc classified_type, confidence,
+ *              cache hit, latency.
+ *   SKIPS    — /api/ingest plumbing (multipart upload, document_extractions
+ *              insert, soft-delete-on-failure). That surface is already
+ *              covered by __tests__/api-ingest.test.ts (17 static fences)
+ *              and by manual curl with a real session cookie when one
+ *              is available.
+ *
+ * Usage:
+ *   npx tsx scripts/dogfood-classify-direct.ts
+ *
+ * Writes qa-reports/qa-branch3-phase3.2-v2-dogfood.md with the same
+ * Expected + Pass/fail columns Jake fills in after the run.
+ */
+import { readFileSync, statSync, readdirSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+
+const DOGFOOD_DIR = "__tests__/fixtures/classifier/.local/dogfood";
+const REPORT_PATH = "qa-reports/qa-branch3-phase3.2-v2-dogfood.md";
+const ORG_ID = "00000000-0000-0000-0000-000000000001";
+const LOW_CONFIDENCE_THRESHOLD = 0.7;
+
+function escapePipe(s: string): string {
+  return s.replace(/\|/g, "\\|");
+}
+
+function countPdfPages(buf: Buffer): number {
+  const text = buf.toString("latin1");
+  const matches = text.match(/\/Type\s*\/Page(?!s)/g);
+  return matches ? matches.length : 0;
+}
+
+type Result = {
+  filename: string;
+  fileSize: number;
+  pageCount: number;
+  classifiedType: string | null;
+  confidence: number | null;
+  cacheHit: boolean | null;
+  inputTokens: number | null;
+  cacheReadTokens: number | null;
+  latencyMs: number;
+  error: string | null;
+};
+
+async function main() {
+  if (!existsSync(DOGFOOD_DIR)) {
+    console.error(`error: fixture dir missing: ${DOGFOOD_DIR}`);
+    process.exit(1);
+  }
+
+  const files = readdirSync(DOGFOOD_DIR)
+    .filter((f) => f.toLowerCase().endsWith(".pdf"))
+    .sort();
+  if (files.length === 0) {
+    console.error(`error: no .pdf files under ${DOGFOOD_DIR}`);
+    process.exit(1);
+  }
+
+  const { classifyDocument } = await import("../src/lib/ingestion/classify");
+
+  console.log(`found ${files.length} fixture(s) under ${DOGFOOD_DIR}`);
+  console.log(`mode: classifier-direct (skips /api/ingest plumbing — see header comment)`);
+  console.log("");
+
+  const runStart = new Date();
+  const results: Result[] = [];
+
+  for (const filename of files) {
+    const path = join(DOGFOOD_DIR, filename);
+    const buf = readFileSync(path);
+    const fileSize = statSync(path).size;
+    const pageCount = countPdfPages(buf);
+
+    process.stdout.write(`→ ${filename} (${(fileSize / 1024).toFixed(1)} KB, ${pageCount}p) ... `);
+
+    const t0 = Date.now();
+    try {
+      const out = await classifyDocument(
+        { pdfBuffer: buf, documentId: `dogfood-${filename}` },
+        {
+          org_id: ORG_ID,
+          user_id: null,
+          metadata: { source: "classifier-dogfood-direct", fixture: `dogfood/${filename}` },
+        }
+      );
+      const latencyMs = Date.now() - t0;
+      results.push({
+        filename,
+        fileSize,
+        pageCount,
+        classifiedType: out.classified_type,
+        confidence: out.classification_confidence,
+        cacheHit: null,
+        inputTokens: null,
+        cacheReadTokens: null,
+        latencyMs,
+        error: null,
+      });
+      console.log(`${out.classified_type} (conf ${out.classification_confidence.toFixed(2)}, ${latencyMs}ms)`);
+    } catch (err) {
+      const latencyMs = Date.now() - t0;
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({
+        filename,
+        fileSize,
+        pageCount,
+        classifiedType: null,
+        confidence: null,
+        cacheHit: null,
+        inputTokens: null,
+        cacheReadTokens: null,
+        latencyMs,
+        error: message,
+      });
+      console.log(`ERROR ${message}`);
+    }
+  }
+
+  // Pull cache metadata from api_usage for the rows we just produced.
+  const sbUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (sbUrl && sbKey) {
+    const { createClient } = await import("@supabase/supabase-js");
+    const sb = createClient(sbUrl, sbKey, { auth: { persistSession: false } });
+    const { data, error } = await sb
+      .from("api_usage")
+      .select("metadata, input_tokens, created_at")
+      .eq("function_type", "document_classify")
+      .gte("created_at", runStart.toISOString())
+      .order("created_at", { ascending: true });
+    if (error) {
+      console.warn(`warn: api_usage query error: ${error.message}`);
+    } else {
+      const usageRows = (data ?? []) as Array<{
+        metadata: Record<string, unknown> | null;
+        input_tokens: number | null;
+        created_at: string;
+      }>;
+      // Match by metadata.fixture (the `dogfood/<filename>` we stamped above).
+      for (const r of results) {
+        const target = `dogfood/${r.filename}`;
+        const row = usageRows.find((u) => {
+          const md = (u.metadata ?? {}) as { fixture?: string };
+          return md.fixture === target;
+        });
+        if (row) {
+          const md = (row.metadata ?? {}) as { cache_read_input_tokens?: unknown };
+          const cacheRead = Number(md.cache_read_input_tokens ?? 0);
+          r.cacheHit = Number.isFinite(cacheRead) && cacheRead > 0;
+          r.cacheReadTokens = cacheRead;
+          r.inputTokens = Number(row.input_tokens ?? 0);
+        }
+      }
+    }
+  }
+
+  // ── Write report ─────────────────────────────────────────────
+  const total = results.length;
+  const succeeded = results.filter((r) => r.error === null).length;
+  const failed = total - succeeded;
+  const lowConf = results.filter(
+    (r) => r.confidence !== null && r.confidence < LOW_CONFIDENCE_THRESHOLD
+  ).length;
+  const cacheKnown = results.filter((r) => r.cacheHit !== null);
+  const cacheHits = cacheKnown.filter((r) => r.cacheHit === true).length;
+  const cacheRate =
+    cacheKnown.length === 0 ? "n/a" : `${((cacheHits / cacheKnown.length) * 100).toFixed(1)}%`;
+  const avgLatency =
+    total === 0 ? 0 : Math.round(results.reduce((s, r) => s + r.latencyMs, 0) / total);
+
+  const lines: string[] = [];
+  lines.push("# Phase 3.2 v2 — dogfood report (classifier-direct mode)");
+  lines.push("");
+  lines.push(`Run window: ${runStart.toISOString()} → ${new Date().toISOString()}`);
+  lines.push(`Mode: **classifier-direct**. Skips /api/ingest plumbing — see §Mode below.`);
+  lines.push(`Fixture root: \`${DOGFOOD_DIR}\` (gitignored — real Ross Built docs only)`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("|---|---|");
+  lines.push(`| Total documents | ${total} |`);
+  lines.push(`| Successful classifications | ${succeeded} |`);
+  lines.push(`| Failed (classifier error) | ${failed} |`);
+  lines.push(`| Low-confidence rows (<${LOW_CONFIDENCE_THRESHOLD}) | ${lowConf} |`);
+  lines.push(`| Avg latency | ${avgLatency} ms |`);
+  lines.push(`| Cache-hit rate (api_usage) | ${cacheRate} |`);
+  lines.push("");
+  lines.push("## Mode — why classifier-direct, not /api/ingest");
+  lines.push("");
+  lines.push("The original dogfood plan POSTed each PDF to `/api/ingest` with Jake's");
+  lines.push("authenticated session cookie. Supabase splits long auth tokens into");
+  lines.push("chunked cookies (`name.0`, `name.1`); when copied from Chrome DevTools");
+  lines.push("and pasted, the chunk boundary loses a few separator characters that");
+  lines.push("aren't recoverable from the visible text — the SSR base64-URL decoder");
+  lines.push("then errors with `Invalid UTF-8 sequence`.");
+  lines.push("");
+  lines.push("Rather than burn another cycle on cookie extraction, this run calls");
+  lines.push("`classifyDocument()` directly on every PDF in the dogfood folder.");
+  lines.push("");
+  lines.push("**What this proves:** the classifier classifies real, unseen Ross Built");
+  lines.push("documents correctly (no overfitting to the eval fixture set).");
+  lines.push("");
+  lines.push("**What this skips:** the `/api/ingest` plumbing — multipart upload,");
+  lines.push("`document_extractions` insert/update with `invoice_id=null`, soft-delete");
+  lines.push("on classifier failure. That surface is covered separately by the 17");
+  lines.push("static fences in `__tests__/api-ingest.test.ts` and by future manual");
+  lines.push("curl-with-cookie when a clean session cookie is available.");
+  lines.push("");
+  lines.push("## Per-fixture results");
+  lines.push("");
+  lines.push("**Jake fills `Expected` and `Pass/fail` after the run.** Use one of the");
+  lines.push("ten enum values for Expected: `invoice`, `purchase_order`, `change_order`,");
+  lines.push("`proposal`, `vendor`, `budget`, `historical_draw`, `plan`, `contract`, `other`.");
+  lines.push("");
+  lines.push("| # | Filename | Size (KB) | Pages | Classified | Confidence | Cache hit | Latency (ms) | Expected | Pass/fail |");
+  lines.push("|---|---|---|---|---|---|---|---|---|---|");
+  results.forEach((r, idx) => {
+    const sizeKB = (r.fileSize / 1024).toFixed(1);
+    const cls = r.classifiedType ?? (r.error ? `ERROR (${r.error})` : "—");
+    const conf = r.confidence === null ? "—" : r.confidence.toFixed(2);
+    const cache = r.cacheHit === null ? "?" : r.cacheHit ? "yes" : "no";
+    lines.push(
+      `| ${idx + 1} | ${escapePipe(r.filename)} | ${sizeKB} | ${r.pageCount} | \`${cls}\` | ${conf} | ${cache} | ${r.latencyMs} | _fill_ | _fill_ |`
+    );
+  });
+  lines.push("");
+
+  if (lowConf > 0) {
+    lines.push("## Low-confidence rows");
+    lines.push("");
+    lines.push(`These rows landed at confidence <${LOW_CONFIDENCE_THRESHOLD} and would be flagged for manual type selection in the eventual Phase 3.10 surface.`);
+    lines.push("");
+    for (const r of results) {
+      if (r.confidence !== null && r.confidence < LOW_CONFIDENCE_THRESHOLD) {
+        lines.push(`- **${escapePipe(r.filename)}** → \`${r.classifiedType}\` at ${r.confidence.toFixed(2)}`);
+      }
+    }
+    lines.push("");
+  }
+
+  if (failed > 0) {
+    lines.push("## Failures");
+    lines.push("");
+    for (const r of results) {
+      if (r.error !== null) {
+        lines.push(`- **${escapePipe(r.filename)}** — ${escapePipe(r.error)}`);
+      }
+    }
+    lines.push("");
+  }
+
+  mkdirSync("qa-reports", { recursive: true });
+  writeFileSync(REPORT_PATH, lines.join("\n"), "utf8");
+  console.log("");
+  console.log(`wrote ${REPORT_PATH}`);
+  console.log(`run complete — ${total} fixture(s), ${failed} failure(s)`);
+  console.log(`open ${REPORT_PATH} and fill in Expected + Pass/fail columns.`);
+}
+
+main().catch((err) => {
+  console.error("dogfood-classify-direct fatal error:", err);
+  process.exit(1);
+});

--- a/scripts/dogfood-ingest.ts
+++ b/scripts/dogfood-ingest.ts
@@ -1,0 +1,387 @@
+/**
+ * Phase 3.2 v2 — /api/ingest dogfood harness.
+ *
+ * Iterates every PDF in __tests__/fixtures/classifier/.local/dogfood/
+ * and POSTs each to the local /api/ingest endpoint using a real
+ * authenticated session cookie. Captures classification responses,
+ * joins to api_usage for cache-hit metadata, and writes a markdown
+ * report at qa-reports/qa-branch3-phase3.2-v2-dogfood.md.
+ *
+ * The report has placeholder columns for "Jake's expected type" and
+ * "Pass/fail" so Jake fills those in after reviewing each result.
+ *
+ * Usage:
+ *   1. npm run dev (separate terminal — leave running)
+ *   2. Drop PDFs into __tests__/fixtures/classifier/.local/dogfood/
+ *      (gitignored; real Ross Built docs only, never committed)
+ *   3. Get a session cookie:
+ *      - Open http://localhost:3000 in a browser, sign in
+ *      - DevTools → Application → Cookies → http://localhost:3000
+ *      - Copy ALL cookies as a single header string, e.g.
+ *        "sb-...-auth-token=...; nw_session=..."
+ *   4. Run:
+ *      DOGFOOD_SESSION_COOKIE='<paste here>' npx tsx scripts/dogfood-ingest.ts
+ *   5. Open qa-reports/qa-branch3-phase3.2-v2-dogfood.md, fill in the
+ *      "Expected" and "Pass/fail" columns per fixture
+ *
+ * The script does NOT delete or modify the document_extractions rows
+ * it creates. Inspect them in the dev DB after the run if you want
+ * to verify the contract (invoice_id=NULL, target_*=NULL, etc.).
+ */
+import { readFileSync, statSync, readdirSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, basename } from "node:path";
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+
+const DOGFOOD_DIR = "__tests__/fixtures/classifier/.local/dogfood";
+const REPORT_PATH = "qa-reports/qa-branch3-phase3.2-v2-dogfood.md";
+const ENDPOINT = process.env.DOGFOOD_ENDPOINT ?? "http://localhost:3000/api/ingest";
+const COOKIE = process.env.DOGFOOD_SESSION_COOKIE ?? "";
+const LOW_CONFIDENCE_THRESHOLD = 0.7;
+
+type IngestResponse = {
+  extraction_id?: string;
+  classified_type?: string;
+  classification_confidence?: number;
+  error?: string;
+};
+
+type Result = {
+  filename: string;
+  fileSize: number;
+  pageCount: number;
+  extractionId: string | null;
+  classifiedType: string | null;
+  confidence: number | null;
+  cacheHit: boolean | null;
+  cacheReadTokens: number | null;
+  inputTokens: number | null;
+  latencyMs: number;
+  status: number;
+  error: string | null;
+};
+
+function fail(msg: string, code = 1): never {
+  console.error(`error: ${msg}`);
+  process.exit(code);
+}
+
+function countPdfPages(buf: Buffer): number {
+  // Heuristic — count occurrences of `/Type /Page` (excluding the
+  // catalog-level `/Type /Pages` collection). Works on every modern
+  // PDF generator we've seen at Ross Built. Returns 0 on parse miss.
+  const text = buf.toString("latin1");
+  const matches = text.match(/\/Type\s*\/Page(?!s)/g);
+  return matches ? matches.length : 0;
+}
+
+function escapePipe(s: string): string {
+  return s.replace(/\|/g, "\\|");
+}
+
+async function postFile(filename: string, buf: Buffer): Promise<{
+  status: number;
+  body: IngestResponse;
+  latencyMs: number;
+}> {
+  const form = new FormData();
+  const blob = new Blob([buf], { type: "application/pdf" });
+  form.append("file", blob, filename);
+
+  const t0 = Date.now();
+  const res = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: { Cookie: COOKIE },
+    body: form,
+  });
+  const latencyMs = Date.now() - t0;
+
+  let body: IngestResponse;
+  try {
+    body = (await res.json()) as IngestResponse;
+  } catch {
+    body = { error: `non-JSON response (status ${res.status})` };
+  }
+
+  return { status: res.status, body, latencyMs };
+}
+
+async function joinCacheMetadata(extractionIds: string[]): Promise<
+  Map<string, { cacheReadTokens: number; inputTokens: number; cacheHit: boolean }>
+> {
+  const out = new Map<string, { cacheReadTokens: number; inputTokens: number; cacheHit: boolean }>();
+  if (extractionIds.length === 0) return out;
+
+  const sbUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!sbUrl || !sbKey) {
+    console.warn(
+      "warn: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing — cache-hit column will be 'unknown'."
+    );
+    return out;
+  }
+
+  const { createClient } = await import("@supabase/supabase-js");
+  const sb = createClient(sbUrl, sbKey, { auth: { persistSession: false } });
+
+  // The /api/ingest route stamps metadata.extraction_id on every classify
+  // call. We pull every classify usage row that matches one of our ids
+  // in a single query.
+  const orFilter = extractionIds
+    .map((id) => `metadata->>extraction_id.eq.${id}`)
+    .join(",");
+  const { data, error } = await sb
+    .from("api_usage")
+    .select("metadata, input_tokens")
+    .eq("function_type", "document_classify")
+    .or(orFilter);
+
+  if (error) {
+    console.warn(`warn: api_usage query error: ${error.message}`);
+    return out;
+  }
+
+  for (const row of (data ?? []) as Array<{
+    metadata: Record<string, unknown> | null;
+    input_tokens: number | null;
+  }>) {
+    const md = (row.metadata ?? {}) as {
+      extraction_id?: string;
+      cache_read_input_tokens?: number;
+    };
+    const id = md.extraction_id;
+    if (!id) continue;
+    const cacheReadTokens = Number(md.cache_read_input_tokens ?? 0);
+    out.set(id, {
+      cacheReadTokens,
+      inputTokens: Number(row.input_tokens ?? 0),
+      cacheHit: cacheReadTokens > 0,
+    });
+  }
+
+  return out;
+}
+
+function writeReport(results: Result[]): void {
+  const total = results.length;
+  const succeeded = results.filter((r) => r.error === null).length;
+  const failed = total - succeeded;
+  const lowConf = results.filter(
+    (r) => r.confidence !== null && r.confidence < LOW_CONFIDENCE_THRESHOLD
+  ).length;
+  const cacheKnown = results.filter((r) => r.cacheHit !== null);
+  const cacheHits = cacheKnown.filter((r) => r.cacheHit === true).length;
+  const cacheRate =
+    cacheKnown.length === 0 ? "n/a" : `${((cacheHits / cacheKnown.length) * 100).toFixed(1)}%`;
+  const avgLatency =
+    total === 0 ? 0 : Math.round(results.reduce((s, r) => s + r.latencyMs, 0) / total);
+
+  const lines: string[] = [];
+  lines.push("# Phase 3.2 v2 — /api/ingest dogfood report");
+  lines.push("");
+  lines.push(`Run window: ${new Date().toISOString()}`);
+  lines.push(`Endpoint: \`${ENDPOINT}\``);
+  lines.push(`Fixture root: \`${DOGFOOD_DIR}\` (gitignored — real Ross Built docs only)`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("|---|---|");
+  lines.push(`| Total documents | ${total} |`);
+  lines.push(`| Successful classifications | ${succeeded} |`);
+  lines.push(`| Failed (HTTP error or no body) | ${failed} |`);
+  lines.push(`| Low-confidence rows (<${LOW_CONFIDENCE_THRESHOLD}) | ${lowConf} |`);
+  lines.push(`| Avg latency | ${avgLatency} ms |`);
+  lines.push(`| Cache-hit rate (api_usage) | ${cacheRate} |`);
+  lines.push("");
+  lines.push("## Per-fixture results");
+  lines.push("");
+  lines.push("**Jake fills `Expected` and `Pass/fail` after the run.** Use one of the");
+  lines.push("ten enum values for Expected: `invoice`, `purchase_order`, `change_order`,");
+  lines.push("`proposal`, `vendor`, `budget`, `historical_draw`, `plan`, `contract`, `other`.");
+  lines.push("");
+  lines.push("| # | Filename | Size (KB) | Pages | Classified | Confidence | Cache hit | Latency (ms) | Extraction id | Expected | Pass/fail |");
+  lines.push("|---|---|---|---|---|---|---|---|---|---|---|");
+  results.forEach((r, idx) => {
+    const sizeKB = (r.fileSize / 1024).toFixed(1);
+    const cls = r.classifiedType ?? (r.error ? `ERROR (${r.error})` : "—");
+    const conf = r.confidence === null ? "—" : r.confidence.toFixed(2);
+    const cache = r.cacheHit === null ? "?" : r.cacheHit ? "yes" : "no";
+    const idShort = r.extractionId ? r.extractionId.slice(0, 8) + "…" : "—";
+    lines.push(
+      `| ${idx + 1} | ${escapePipe(r.filename)} | ${sizeKB} | ${r.pageCount} | \`${cls}\` | ${conf} | ${cache} | ${r.latencyMs} | \`${idShort}\` | _fill_ | _fill_ |`
+    );
+  });
+  lines.push("");
+
+  if (lowConf > 0) {
+    lines.push("## Low-confidence rows");
+    lines.push("");
+    lines.push(`These rows landed at confidence <${LOW_CONFIDENCE_THRESHOLD} and would be flagged for manual type selection in the eventual Phase 3.10 surface.`);
+    lines.push("");
+    for (const r of results) {
+      if (r.confidence !== null && r.confidence < LOW_CONFIDENCE_THRESHOLD) {
+        lines.push(`- **${escapePipe(r.filename)}** → \`${r.classifiedType}\` at ${r.confidence.toFixed(2)} (extraction \`${r.extractionId}\`)`);
+      }
+    }
+    lines.push("");
+  }
+
+  if (failed > 0) {
+    lines.push("## Failures");
+    lines.push("");
+    for (const r of results) {
+      if (r.error !== null) {
+        lines.push(`- **${escapePipe(r.filename)}** (HTTP ${r.status}) — ${escapePipe(r.error)}`);
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("## Inspect rows in dev DB");
+  lines.push("");
+  lines.push("The script does NOT delete or modify the rows it creates. To verify the contract:");
+  lines.push("");
+  lines.push("```sql");
+  lines.push("SELECT id, classified_type, classification_confidence,");
+  lines.push("       invoice_id, target_entity_type, target_entity_id,");
+  lines.push("       verification_status, raw_pdf_url");
+  lines.push("FROM document_extractions");
+  if (results.some((r) => r.extractionId)) {
+    const ids = results
+      .map((r) => r.extractionId)
+      .filter((x): x is string => Boolean(x));
+    lines.push(`WHERE id IN (${ids.map((id) => `'${id}'`).join(", ")});`);
+  } else {
+    lines.push("-- no extractions created this run");
+  }
+  lines.push("```");
+  lines.push("");
+  lines.push("Expected per row: `invoice_id` IS NULL, `target_entity_type` IS NULL, `target_entity_id` IS NULL, `verification_status='pending'`, `classified_type` set, `classification_confidence` set, `raw_pdf_url` points at `{org_id}/ingest/...`.");
+  lines.push("");
+
+  mkdirSync("qa-reports", { recursive: true });
+  writeFileSync(REPORT_PATH, lines.join("\n"), "utf8");
+  console.log(`wrote ${REPORT_PATH}`);
+}
+
+async function main() {
+  if (!COOKIE) {
+    fail(
+      "DOGFOOD_SESSION_COOKIE env var is empty. Get a real session cookie from the browser " +
+        "(http://localhost:3000 → DevTools → Application → Cookies, copy as a single header string) " +
+        "and re-run as: DOGFOOD_SESSION_COOKIE='...' npx tsx scripts/dogfood-ingest.ts"
+    );
+  }
+
+  if (!existsSync(DOGFOOD_DIR)) {
+    fail(`fixture dir missing: ${DOGFOOD_DIR}. Drop ≥1 .pdf into it and re-run.`);
+  }
+
+  const files = readdirSync(DOGFOOD_DIR)
+    .filter((f) => f.toLowerCase().endsWith(".pdf"))
+    .sort();
+  if (files.length === 0) {
+    fail(`no .pdf files under ${DOGFOOD_DIR}. Drop ≥1 and re-run.`);
+  }
+
+  console.log(`found ${files.length} fixture(s) under ${DOGFOOD_DIR}`);
+  console.log(`POSTing to ${ENDPOINT}`);
+  console.log("");
+
+  const results: Result[] = [];
+
+  for (const filename of files) {
+    const path = join(DOGFOOD_DIR, filename);
+    const buf = readFileSync(path);
+    const fileSize = statSync(path).size;
+    const pageCount = countPdfPages(buf);
+
+    process.stdout.write(`→ ${filename} (${(fileSize / 1024).toFixed(1)} KB, ${pageCount}p) ... `);
+
+    let result: Result;
+    try {
+      const { status, body, latencyMs } = await postFile(filename, buf);
+      if (status === 200 && body.classified_type && typeof body.classification_confidence === "number") {
+        result = {
+          filename,
+          fileSize,
+          pageCount,
+          extractionId: body.extraction_id ?? null,
+          classifiedType: body.classified_type,
+          confidence: body.classification_confidence,
+          cacheHit: null,
+          cacheReadTokens: null,
+          inputTokens: null,
+          latencyMs,
+          status,
+          error: null,
+        };
+        console.log(
+          `${body.classified_type} (conf ${body.classification_confidence.toFixed(2)}, ${latencyMs}ms)`
+        );
+      } else {
+        result = {
+          filename,
+          fileSize,
+          pageCount,
+          extractionId: null,
+          classifiedType: null,
+          confidence: null,
+          cacheHit: null,
+          cacheReadTokens: null,
+          inputTokens: null,
+          latencyMs,
+          status,
+          error: body.error ?? `unexpected response shape (status ${status})`,
+        };
+        console.log(`FAIL HTTP ${status} — ${result.error}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      result = {
+        filename,
+        fileSize,
+        pageCount,
+        extractionId: null,
+        classifiedType: null,
+        confidence: null,
+        cacheHit: null,
+        cacheReadTokens: null,
+        inputTokens: null,
+        latencyMs: 0,
+        status: 0,
+        error: message,
+      };
+      console.log(`FAIL ${message}`);
+    }
+
+    results.push(result);
+  }
+
+  console.log("");
+  console.log("joining api_usage for cache-hit metadata...");
+  const ids = results.map((r) => r.extractionId).filter((x): x is string => Boolean(x));
+  const cacheMap = await joinCacheMetadata(ids);
+  for (const r of results) {
+    if (!r.extractionId) continue;
+    const stat = cacheMap.get(r.extractionId);
+    if (stat) {
+      r.cacheHit = stat.cacheHit;
+      r.cacheReadTokens = stat.cacheReadTokens;
+      r.inputTokens = stat.inputTokens;
+    }
+  }
+
+  console.log("");
+  writeReport(results);
+  console.log("");
+  console.log(`run complete — ${results.length} fixture(s), ${results.filter((r) => r.error).length} failure(s)`);
+  console.log(`open ${REPORT_PATH} and fill in the Expected + Pass/fail columns per row.`);
+}
+
+main().catch((err) => {
+  console.error("dogfood-ingest fatal error:", err);
+  process.exit(1);
+});

--- a/scripts/dogfood-ingest.ts
+++ b/scripts/dogfood-ingest.ts
@@ -86,7 +86,7 @@ async function postFile(filename: string, buf: Buffer): Promise<{
   latencyMs: number;
 }> {
   const form = new FormData();
-  const blob = new Blob([buf], { type: "application/pdf" });
+  const blob = new Blob([new Uint8Array(buf)], { type: "application/pdf" });
   form.append("file", blob, filename);
 
   const t0 = Date.now();

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+import { getCurrentMembership } from "@/lib/org/session";
+import { ApiError, withApiError } from "@/lib/api/errors";
+import { classifyDocument } from "@/lib/ingestion/classify";
+import { PlanLimitError } from "@/lib/claude";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+const ACCEPTED_MIME = new Set(["application/pdf"]);
+
+export const POST = withApiError(async (request: NextRequest) => {
+  const membership = await getCurrentMembership();
+  if (!membership) throw new ApiError("Not authenticated", 401);
+
+  const formData = await request.formData();
+  const file = formData.get("file") as File | null;
+  if (!file) throw new ApiError("No file provided", 400);
+
+  if (!ACCEPTED_MIME.has(file.type)) {
+    throw new ApiError(
+      `Unsupported file type: ${file.type || "<unknown>"}. Only application/pdf is accepted by /api/ingest in v2.`,
+      400
+    );
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  const supabase = createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const timestamp = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const storagePath = `${membership.org_id}/ingest/${timestamp}_${safeName}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from("invoice-files")
+    .upload(storagePath, buffer, { contentType: file.type, upsert: false });
+
+  if (uploadError) {
+    console.error("[api/ingest] storage upload failed:", uploadError.message);
+    throw new ApiError(`Storage upload failed: ${uploadError.message}`, 500);
+  }
+
+  const { data: inserted, error: insertError } = await supabase
+    .from("document_extractions")
+    .insert({
+      org_id: membership.org_id,
+      invoice_id: null,
+      raw_pdf_url: storagePath,
+      verification_status: "pending",
+      extraction_model: "classifier-only",
+      extraction_prompt_version: "phase-3.2-v2",
+    })
+    .select("id")
+    .single();
+
+  if (insertError || !inserted) {
+    console.error("[api/ingest] document_extractions insert failed:", insertError?.message);
+    throw new ApiError(
+      `Failed to create document_extractions row: ${insertError?.message ?? "no row returned"}`,
+      500
+    );
+  }
+
+  const extractionId = inserted.id as string;
+
+  try {
+    const classification = await classifyDocument(
+      { pdfBuffer: buffer, documentId: extractionId },
+      {
+        org_id: membership.org_id,
+        user_id: user?.id ?? null,
+        metadata: { source: "api/ingest", extraction_id: extractionId },
+      }
+    );
+
+    const { error: updateError } = await supabase
+      .from("document_extractions")
+      .update({
+        classified_type: classification.classified_type,
+        classification_confidence: classification.classification_confidence,
+      })
+      .eq("id", extractionId)
+      .eq("org_id", membership.org_id);
+
+    if (updateError) {
+      console.error("[api/ingest] update after classify failed:", updateError.message);
+      throw new ApiError(`Failed to record classification: ${updateError.message}`, 500);
+    }
+
+    return NextResponse.json({
+      extraction_id: extractionId,
+      classified_type: classification.classified_type,
+      classification_confidence: classification.classification_confidence,
+    });
+  } catch (err) {
+    // The verification_status enum has no 'failed' value, so we soft-delete
+    // the row (deleted_at = now()) to keep it out of active queries while
+    // preserving the audit trail. The api_usage row already records the
+    // attempted call. Re-throw so withApiError emits the right status.
+    await supabase
+      .from("document_extractions")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", extractionId)
+      .eq("org_id", membership.org_id);
+
+    if (err instanceof PlanLimitError) {
+      return NextResponse.json(
+        {
+          error: "AI call limit reached",
+          current: err.current,
+          limit: err.limit,
+          plan: err.plan,
+        },
+        { status: 429 }
+      );
+    }
+
+    const message = err instanceof Error ? err.message : "Unknown classifier error";
+    console.error("[api/ingest] classifier failed:", message);
+    throw new ApiError(`Classifier failed: ${message}`, 500);
+  }
+});

--- a/src/lib/ingestion/classify.ts
+++ b/src/lib/ingestion/classify.ts
@@ -158,7 +158,7 @@ export async function classifyDocument(
 
   if (!isClassifiedType(parsed.classified_type)) {
     console.warn(
-      `[classify-document] Unknown classified_type "${String(parsed.classified_type)}" — defaulting to other with confidence 0`
+      `[ingestion/classify] Unknown classified_type "${String(parsed.classified_type)}" — defaulting to other with confidence 0`
     );
     return { classified_type: "other", classification_confidence: 0 };
   }

--- a/supabase/migrations/00081_document_extractions_invoice_id_nullable.down.sql
+++ b/supabase/migrations/00081_document_extractions_invoice_id_nullable.down.sql
@@ -1,0 +1,27 @@
+-- Down migration for 00081.
+--
+-- Drops the type-aware CHECK and re-asserts NOT NULL on invoice_id.
+-- Re-adding NOT NULL will FAIL if any rows have been inserted with
+-- NULL invoice_id since 00081 was applied (which is expected as soon
+-- as Phase 3.2 v2's /api/ingest classify-only path lands and writes
+-- non-invoice document_extractions rows).
+--
+-- This failure is intentional. A down migration must not silently
+-- discard rows. If you need to roll back 00081 after non-invoice
+-- ingestions have happened, you must first decide whether to:
+--   (a) export and remove those rows (data loss, but clean rollback),
+--   (b) backfill invoice_id with placeholder invoice rows (preserves
+--       data but creates synthetic invoices — usually wrong),
+--   (c) abandon the rollback and forward-fix instead.
+--
+-- The first ALTER below should be run only after one of (a)/(b)/(c)
+-- is decided.
+
+ALTER TABLE public.document_extractions
+  DROP CONSTRAINT IF EXISTS document_extractions_invoice_id_required_when_invoice_target;
+
+ALTER TABLE public.document_extractions
+  ALTER COLUMN invoice_id SET NOT NULL;
+
+COMMENT ON COLUMN public.document_extractions.invoice_id IS
+  'FK to invoices.id. NOT NULL — every extraction must be tied to an invoice (Phase 3.1 baseline shape).';

--- a/supabase/migrations/00081_document_extractions_invoice_id_nullable.sql
+++ b/supabase/migrations/00081_document_extractions_invoice_id_nullable.sql
@@ -1,0 +1,63 @@
+-- Migration 00081 — relax document_extractions.invoice_id to nullable
+--
+-- Phase 3.2 v2 — unblocks the universal /api/ingest route. v1 of Phase
+-- 3.2 (Path Z, commit 975e06e) deferred /api/ingest entirely because
+-- document_extractions.invoice_id was NOT NULL with an FK to invoices.
+-- That meant the row could only be inserted in a flow that had already
+-- created an invoice — which defeats the purpose of a type-agnostic
+-- classifier endpoint that may be classifying a PO, CO, proposal, etc.
+--
+-- Phase 3.1 (migration 00076) renamed invoice_extractions →
+-- document_extractions but explicitly preserved the invoice_id FK and
+-- NOT NULL constraint to keep the rename behavior-preserving. That was
+-- correct sequencing for 3.1; 3.2 v2 now needs the actual relaxation.
+-- Phases 3.3–3.8 (PO / CO / proposal / vendor / budget / historical_draw
+-- extraction pipelines) all require this nullability — they will
+-- populate target_entity_type and target_entity_id at commit time, with
+-- invoice_id staying NULL whenever the document is not an invoice.
+--
+-- Why a CHECK guards target_entity_type='invoice':
+--   When an extraction IS committed against an invoice (the existing
+--   Phase 3.1 path, target_entity_type='invoice'), invoice_id MUST be
+--   populated so downstream FKs and the existing invoice ↔ extraction
+--   relationship continue to work. The CHECK enforces that
+--   invariant at the database level so a future writer cannot leave
+--   target_entity_type='invoice' with NULL invoice_id.
+--
+--   For target_entity_type IN ('purchase_order','change_order',
+--   'proposal','vendor','budget','historical_draw') OR NULL, the
+--   invoice_id field is allowed to remain NULL.
+--
+-- Pre-deploy verification (must return 0 before applying):
+--   SELECT count(*) FROM public.document_extractions
+--   WHERE target_entity_type = 'invoice' AND invoice_id IS NULL;
+-- Verified 0 on dev 2026-04-27 prior to authoring this migration.
+--
+-- Slot note: spec called for slot 00080, but 00080 was consumed by the
+-- Phase A lockdown's RLS-enable migration (commit 37f0891, PR #23,
+-- merged 2026-04-27). This migration takes the next free slot 00081.
+-- No semantic change from the spec; only the numeric prefix shifted.
+--
+-- Blast radius: SMALL.
+--   - 1 column constraint relaxed (DROP NOT NULL on invoice_id).
+--   - 1 CHECK constraint added enforcing the type-aware requirement.
+--   - 0 rows mutated. All 57 existing rows already satisfy the new
+--     CHECK (every existing row has both invoice_id populated and
+--     classified_type='invoice'; the existing target_entity_type
+--     column was added by 00076 and is NULL on every existing row, so
+--     the predicate `target_entity_type IS DISTINCT FROM 'invoice'`
+--     resolves to TRUE for all existing rows — they pass the CHECK).
+--   - Down migration drops the CHECK and re-adds NOT NULL. Re-adding
+--     NOT NULL will fail if any rows have been inserted with NULL
+--     invoice_id by then, which is the correct behavior — a down
+--     migration must not silently discard data.
+
+ALTER TABLE public.document_extractions
+  ALTER COLUMN invoice_id DROP NOT NULL;
+
+ALTER TABLE public.document_extractions
+  ADD CONSTRAINT document_extractions_invoice_id_required_when_invoice_target
+  CHECK (target_entity_type IS DISTINCT FROM 'invoice' OR invoice_id IS NOT NULL);
+
+COMMENT ON COLUMN public.document_extractions.invoice_id IS
+  'Nullable as of migration 00081. Required only when target_entity_type=''invoice'' (enforced by document_extractions_invoice_id_required_when_invoice_target). NULL during the Phase 3.2 classify step and during Phase 3.3-3.8 pre-commit extraction for non-invoice document types. Populated at commit time alongside target_entity_type=''invoice'' for the invoice path.';


### PR DESCRIPTION
## Summary

- Closes Path Z from v1 — `/api/ingest` route shipped, schema unblocked, eval expanded to full 10-category coverage.
- **Parallel-deploy**: legacy `/api/invoices/parse` flow byte-identical to its pre-v2 form. Static fence #17 enforces this in CI going forward.
- 100% accuracy on 36 real Ross Built fixtures across 9 of 10 enum categories. Zero re-labels. Zero prompt iterations needed.
- 100% accuracy on 6 novel real-world dogfood docs (none in eval set).

## Exit gate status

All 6 plan-doc exit-gate items PASS. Full per-fixture detail:

- Eval results: [`qa-reports/qa-branch3-phase3.2-v2.md`](./qa-reports/qa-branch3-phase3.2-v2.md)
- Dogfood results: [`qa-reports/qa-branch3-phase3.2-v2-dogfood.md`](./qa-reports/qa-branch3-phase3.2-v2-dogfood.md)

| # | Gate | Status |
|---|---|---|
| 1 | ≥90% accuracy on test set | PASS — 36/36 = 100% |
| 2 | `/api/ingest` accepts file → creates row with `classified_type` | PASS — 17 structural fences |
| 3 | `classification_confidence` recorded; <0.70 queryable | PASS |
| 4 | All classifier tests PASS | PASS — `npm test` green; `RUN_CLASSIFIER_EVAL=1` 36/36 |
| 5 | Prompt cached, hit on second call | PASS — 35/36 hits, first hit at idx 1 |
| 6 | QA report with per-fixture data | PASS — see linked reports |

Path B exit gate (per prompt 153): overall ≥90% PASS, fat-category ≥80% PASS on all 6 fat categories at 100%, zero thin-category misses to investigate.

## Commits (10)

```
b9f83e1 qa(branch3): correct §13 build status — TS error in dogfood script, not pre-existing /admin
bb4be24 fix(test): eval skips non-category subdirs (dogfood) when discovering classifier categories
ed1f39a fix(scripts): dogfood-ingest TypeScript Buffer→Blob compatibility
deaab87 qa(branch3): phase 3.2 v2 dogfood — 6/6 classifier accuracy, route-behavior gap documented
5bf9cdf tooling(ingestion): scripts/dogfood-ingest.ts harness
552ddb0 qa(branch3): phase 3.2 v2 report — classifier production-ready
40017fc test(classifier): full 10-category eval coverage
9a58793 feat(ingestion): /api/ingest route — parallel to invoices/parse
1c05c55 feat(ingestion): allow nullable invoice_id with target-aware CHECK
646f2d4 refactor(ingestion): relocate classifier to src/lib/ingestion/classify.ts
```

## Schema change (1) — Jake-approved Path A

Migration `00081_document_extractions_invoice_id_nullable.sql`:
- `ALTER document_extractions.invoice_id DROP NOT NULL`
- `ADD CHECK target_entity_type IS DISTINCT FROM 'invoice' OR invoice_id IS NOT NULL`
- Pre-deploy verification (rows where `target_entity_type='invoice' AND invoice_id IS NULL`): 0
- Phases 3.3–3.8 require this nullability — doing it now in v2 is correct sequencing.

Slot note: spec called for 00080, but 00080 was consumed by Phase A's RLS-enable migration (PR #23). Rolled forward to 00081. No semantic change.

## Production gaps before cutover

The first real-world HTTP test of `/api/ingest` will happen on the first authenticated upload after merge. The dogfood was run via `classifyDocument()` direct (commit `deaab87`) because Jake's chunked Supabase auth cookie couldn't be reliably reconstructed from a paste — the SSR base64-URL decoder errored with `Invalid UTF-8 sequence`. The classifier accuracy was decisively proven (6/6 on novel docs). The HTTP route plumbing is covered by 17 static fences but has not been exercised end-to-end under real session auth. Specifically not exercised:

1. The `/api/ingest` HTTP route under real session auth.
2. DB writes through the live route flow (`document_extractions` insert with `invoice_id=null`).
3. Org-scoping enforcement under real auth.
4. Storage upload to `{org_id}/ingest/...`.
5. Soft-delete-on-failure path.

Watch the first real upload after merge:
- `document_extractions` row appears with `invoice_id=null`, `target_entity_*` NULL, `verification_status='pending'`.
- `raw_pdf_url` points at `{org_id}/ingest/{ts}_{name}.pdf`.
- `classified_type` + `classification_confidence` populate after classifier returns.
- A deliberate failure (e.g., 0-byte file) triggers soft-delete and structured 500.

If any misbehave, rollback is reverting commit `9a58793`.

## What's NOT in this PR (out of scope)

- UI integration of `/api/ingest` (Phase 3.10).
- Extraction pipelines for non-invoice types (Phases 3.3–3.8).
- Manual type-selection surface for low-confidence rows (Phase 3.10).
- Migrating existing invoice flow off `/api/invoices/parse` (separate cutover decision after dogfooding).
- The `fix-admin-build` branch envisioned in the original ship plan was abandoned without commits — turns out the `/admin` build error was transient `.next/` cache corruption, not a real bug. The actual build failure that surfaced on v2 was a TypeScript error in the new `scripts/dogfood-ingest.ts` (Buffer→Blob compat under Node 24) which was fixed inline (`ed1f39a`) plus a related eval-discovery break from the dogfood folder fixed in `bb4be24`. QA §13.1 documents the corrected story honestly.

## Final check status (HEAD `b9f83e1`)

| Check | Status |
|---|---|
| `npm run lint` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | all green |
| `RUN_CLASSIFIER_EVAL=1 npm test` | 36/36 = 100%, cache verified |

## Test plan

- [ ] Review `qa-reports/qa-branch3-phase3.2-v2.md` end-to-end (especially §10 cutover plan, §11 fixture top-up, §13 build status correction).
- [ ] Review `qa-reports/qa-branch3-phase3.2-v2-dogfood.md` (especially "What was NOT tested" section).
- [ ] On first real upload through `/api/ingest` post-merge, verify the 4 contract invariants in §10 of the main QA report.
- [ ] Confirm legacy `/api/invoices/parse` upload path still works end-to-end.
- [ ] Decide on fixture top-up timing: `historical_draw` (0), `plan` (need 2 more), `budget` (need 1 more).

🤖 Generated with [Claude Code](https://claude.com/claude-code)