### PR TITLE
test(harness): bump classifier eval timeout for API latency tolerance

### DIFF
--- a/__tests__/document-classifier.test.ts
+++ b/__tests__/document-classifier.test.ts
@@ -48,7 +48,7 @@ const FIXTURE_ROOT = "__tests__/fixtures/classifier/.local";
 const RESULTS_DIR = "qa-reports/.eval";
 const RESULTS_FILE = join(RESULTS_DIR, "phase3.2-v2-eval.md");
 const ORG_ID = "00000000-0000-0000-0000-000000000001";
-const CALL_TIMEOUT_MS = 15_000;
+const CALL_TIMEOUT_MS = 30_000;
 
 // Phase 3.2 v2 Path B exit-gate parameters
 const OVERALL_GATE = 0.9;


### PR DESCRIPTION
## Summary

- One-line change: `CALL_TIMEOUT_MS = 15_000` → `30_000` in `__tests__/document-classifier.test.ts`
- Test harness only — no production code touched
- Eliminates flaky timeouts on fixtures that legitimately take 12–15s on the Anthropic API under load

## Why

Recent regression-baseline runs (from Phase 3.4 development) hit intermittent timeouts on different fixtures across runs:

| Fixture | Timeout duration | Historical fast time |
|---|---|---|
| `fish po 1.pdf` | 14997ms | 6393ms (well under) |
| `Certificate.pdf` | 15012ms | 12527ms (~2.5s headroom against 15s) |
| `Markgraf 03112.pdf` | 15013ms | 4604ms |

The pattern: when the API is slower than usual, fixtures that historically finished in 12–14 seconds cross the 15s wall by single-digit milliseconds. No fixture has ever run anywhere near 30s, so the new wall remains a real performance gate.

## Validation — 3 consecutive eval runs on this branch

| Run | Result | Notes |
|---|---|---|
| 1 | 35/36 | Single fail on `10_Home_Depot_Receipts.pdf` classified as `other` (conf 0.85, 2318ms) — NOT a timeout, model boundary flake on retail-receipt format |
| 2 | 36/36 | Clean |
| 3 | 36/36 | Clean |

The Home Depot fixture's flake is unrelated to this fix and pre-existed it (4 prior runs classified it as `invoice`, today's run 1 flipped to `other`). Tracked as a follow-up issue: see "Phase 3.2 v3 — `10_Home_Depot_Receipts.pdf` classifies inconsistently between 'invoice' and 'other' on rerun" (label: phase-3.2-v3, classifier).

This timeout fix benefits Phases 3.4–3.10 — every phase will run the classifier regression baseline as part of its exit gate, and a flaky 15s wall would create noise in every PR's verification block.

## Test plan

- [x] `RUN_CLASSIFIER_EVAL=1 npx tsx __tests__/document-classifier.test.ts` — runs 1, 2, 3 (above)
- [x] No production code modified — `git diff` is one line in the test file
- [x] Cache verified on every run (35–39 cache reads, first hit at row index 0–1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)